### PR TITLE
Keep whitespaces during A1<->R1C1 conversion

### DIFF
--- a/src/ClosedXML.Parser.Tests/FormulaConverterToR1C1Tests.cs
+++ b/src/ClosedXML.Parser.Tests/FormulaConverterToR1C1Tests.cs
@@ -15,14 +15,14 @@ public class FormulaConverterToR1C1Tests
     }
 
     [Theory]
-    [InlineData(" { 1 } ", "{1}")]
-    [InlineData("{1,2} ", "{1,2}")]
-    [InlineData("{1;2} ", "{1;2}")]
-    [InlineData("{1,2;3,4} ", "{1,2;3,4}")]
-    [InlineData("{TRUE} ", "{TRUE}")]
-    [InlineData("{#DIV/0!} ", "{#DIV/0!}")]
-    [InlineData("{\"\"} ", "{\"\"}")]
-    [InlineData("{\"Hello world\"} ", "{\"Hello world\"}")]
+    [InlineData(" { 1 }   ", " { 1 }   ")]
+    [InlineData("{1,2}", "{1,2}")]
+    [InlineData("{1;2}", "{1;2}")]
+    [InlineData("{ 1, 2;  3, 4 }", "{ 1, 2;  3, 4 }")]
+    [InlineData("{TRUE}", "{TRUE}")]
+    [InlineData("{ #DIV/0! } ", "{ #DIV/0! } ")]
+    [InlineData("{ \"\"}", "{ \"\"}")]
+    [InlineData("{ \"Hello world\" }", "{ \"Hello world\" }")]
     public void Array(string a1, string r1c1)
     {
         Assert.Equal(r1c1, FormulaConverter.ToR1C1(a1, 1, 1));
@@ -79,8 +79,9 @@ public class FormulaConverterToR1C1Tests
 
     [Theory]
     [InlineData("RAND()", 4, 1, "RAND()")]
-    [InlineData("SIN(F8)", 2, 3, "SIN(R[6]C[3])")]
-    [InlineData("MOD(F8, $A$1)", 2, 3, "MOD(R[6]C[3],R1C1)")]
+    [InlineData("RAND(   )  ", 4, 1, "RAND(   )  ")]
+    [InlineData("SIN( F8 ) ", 2, 3, "SIN( R[6]C[3] ) ")]
+    [InlineData("MOD(F8 ,  $A$1)", 2, 3, "MOD(R[6]C[3] ,  R1C1)")]
     [InlineData("IF(TRUE,,)", 2, 3, "IF(TRUE,,)")]
     public void Function(string a1, int row, int col, string r1c1)
     {
@@ -90,6 +91,7 @@ public class FormulaConverterToR1C1Tests
     [Theory]
     [InlineData("Sheet1!UDF.SHEET.FUNC($F$1)", 4, 1, "Sheet1!UDF.SHEET.FUNC(R1C6)")]
     [InlineData("'Johnny''s'!UDF.SHEET.FUNC($F$1)", 4, 1, "'Johnny''s'!UDF.SHEET.FUNC(R1C6)")]
+    [InlineData("Sheet1!UDF.SHEET.FUNC( $F$1  ) ", 4, 1, "Sheet1!UDF.SHEET.FUNC( R1C6  ) ")]
     public void SheetFunction(string a1, int row, int col, string r1c1)
     {
         Assert.Equal(r1c1, FormulaConverter.ToR1C1(a1, row, col));
@@ -97,6 +99,7 @@ public class FormulaConverterToR1C1Tests
 
     [Theory]
     [InlineData("[4]!UDF.SHEET.FUNC($F$1)", 4, 1, "[4]!UDF.SHEET.FUNC(R1C6)")]
+    [InlineData("[4]!UDF.SHEET.FUNC( $F$1  )", 4, 1, "[4]!UDF.SHEET.FUNC( R1C6  )")]
     public void ExternalFunction(string a1, int row, int col, string r1c1)
     {
         Assert.Equal(r1c1, FormulaConverter.ToR1C1(a1, row, col));
@@ -105,13 +108,16 @@ public class FormulaConverterToR1C1Tests
     [Theory]
     [InlineData("[4]Sheet1!UDF.SHEET.FUNC($F$1)", 4, 1, "[4]Sheet1!UDF.SHEET.FUNC(R1C6)")]
     [InlineData("'[7]Johnny''s'!UDF.SHEET.FUNC($F$1)", 4, 1, "'[7]Johnny''s'!UDF.SHEET.FUNC(R1C6)")]
+    [InlineData("[2]Sheet1!F(  ) ", 4, 1, "[2]Sheet1!F(  ) ")]
+    [InlineData("[2]Sheet1!F(  $A$2,$F$1 ) ", 4, 1, "[2]Sheet1!F(  R2C1,R1C6 ) ")]
     public void ExternalSheetFunction(string a1, int row, int col, string r1c1)
     {
         Assert.Equal(r1c1, FormulaConverter.ToR1C1(a1, row, col));
     }
 
     [Theory]
-    [InlineData("$A$5(TRUE, 7)", 10, 15, "R5C1(TRUE,7)")]
+    [InlineData("$A$5(TRUE,7)", 10, 15, "R5C1(TRUE,7)")]
+    [InlineData("$A$5(TRUE ,  7)", 10, 15, "R5C1(TRUE ,  7)")]
     public void CellFunction(string a1, int row, int col, string r1c1)
     {
         Assert.Equal(r1c1, FormulaConverter.ToR1C1(a1, row, col));
@@ -154,7 +160,7 @@ public class FormulaConverterToR1C1Tests
     }
 
     [Theory]
-    [InlineData(" some_name + other_name", 1, 1, "some_name+other_name")]
+    [InlineData(" some_name + other_name", 1, 1, "some_name + other_name")]
     public void Name(string a1, int row, int col, string r1c1)
     {
         Assert.Equal(r1c1, FormulaConverter.ToR1C1(a1, row, col));
@@ -186,7 +192,8 @@ public class FormulaConverterToR1C1Tests
     [Theory]
     [InlineData("+B3", 1, 1, "+R[2]C[1]")]
     [InlineData("-8", 1, 1, "-8")]
-    [InlineData("100 %", 1, 1, "100%")]
+    [InlineData(" - 8 ", 1, 1, " - 8 ")]
+    [InlineData("100 %", 1, 1, "100 %")]
     [InlineData("@D8", 2, 5, "@R[6]C[-1]")]
     [InlineData("D8#", 2, 5, "R[6]C[-1]#")]
     public void Unary(string a1, int row, int col, string r1c1)
@@ -195,8 +202,18 @@ public class FormulaConverterToR1C1Tests
     }
 
     [Theory]
-    [InlineData("(1 + 2) / 4", 1, 1, "(1+2)/4")]
-    [InlineData("(1+((3 + A4)))", 1, 1, "(1+((3+R[3]C)))")]
+    [InlineData("5+1", 1, 1, "5+1")]
+    [InlineData("5 +  1 ", 1, 1, "5 +  1 ")]
+    [InlineData("B3 +  $D$8 ", 1, 1, "R[2]C[1] +  R8C4 ")]
+    [InlineData("B3 /  $D$8 ", 1, 1, "R[2]C[1] /  R8C4 ")]
+    public void Binary(string a1, int row, int col, string r1c1)
+    {
+        Assert.Equal(r1c1, FormulaConverter.ToR1C1(a1, row, col));
+    }
+
+    [Theory]
+    [InlineData(" ( 1 + 2 ) / 4", 1, 1, " ( 1 + 2 ) / 4")]
+    [InlineData("(1+((3 + A4)))", 1, 1, "(1+((3 + R[3]C)))")]
     public void Nested(string a1, int row, int col, string r1c1)
     {
         Assert.Equal(r1c1, FormulaConverter.ToR1C1(a1, row, col));

--- a/src/ClosedXML.Parser/ClosedXML.Parser.csproj
+++ b/src/ClosedXML.Parser/ClosedXML.Parser.csproj
@@ -54,6 +54,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All" />
     <PackageReference Include="System.Memory" Version="4.5.4" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>

--- a/src/ClosedXML.Parser/ClosedXML.Parser.csproj
+++ b/src/ClosedXML.Parser/ClosedXML.Parser.csproj
@@ -17,7 +17,7 @@
     <PackageProjectUrl>https://github.com/ClosedXML/ClosedXML.Parser</PackageProjectUrl>
     <RepositoryUrl>https://github.com/ClosedXML/ClosedXML.Parser</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageVersion>1.0.0</PackageVersion>
+    <PackageVersion>1.0.1</PackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/src/ClosedXML.Parser/FormulaConverter.cs
+++ b/src/ClosedXML.Parser/FormulaConverter.cs
@@ -1,8 +1,11 @@
-﻿namespace ClosedXML.Parser;
+﻿using JetBrains.Annotations;
+
+namespace ClosedXML.Parser;
 
 /// <summary>
 /// Convert between <em>A1</em> and <em>R1C1</em> style formulas.
 /// </summary>
+[PublicAPI]
 public static class FormulaConverter
 {
     private static readonly TextVisitorR1C1 s_visitorR1C1 = new();

--- a/src/ClosedXML.Parser/FormulaGeneratorVisitor.cs
+++ b/src/ClosedXML.Parser/FormulaGeneratorVisitor.cs
@@ -341,8 +341,9 @@ internal class FormulaGeneratorVisitor : IAstFactory<TransformedSymbol, Transfor
     public virtual TransformedSymbol Nested(TransformContext ctx, SymbolRange range, TransformedSymbol node)
     {
         var nodeText = new StringBuilder(node.Length + 2)
-            .Append('(').Append(node.AsSpan())
-            .Append(')')
+            .AppendStartFragment(ctx, range, node)
+            .Append(node.AsSpan())
+            .AppendEndFragment(ctx, range, node)
             .ToString();
         return TransformedSymbol.ToText(ctx.Formula, range, nodeText);
     }

--- a/src/ClosedXML.Parser/FormulaParser.cs
+++ b/src/ClosedXML.Parser/FormulaParser.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using ClosedXML.Parser.Rolex;
+using JetBrains.Annotations;
 
 namespace ClosedXML.Parser;
 
@@ -15,6 +16,7 @@ namespace ClosedXML.Parser;
 /// <typeparam name="TScalarValue">Type of a scalar value used across expressions.</typeparam>
 /// <typeparam name="TNode">Type of a node used in the AST.</typeparam>
 /// <typeparam name="TContext">A context of the parsing. It's passed to every factory method and can contain global info that doesn't belong individual nodes.</typeparam>
+[PublicAPI]
 public class FormulaParser<TScalarValue, TNode, TContext>
 {
     private readonly string _input;

--- a/src/ClosedXML.Parser/IAstFactory.cs
+++ b/src/ClosedXML.Parser/IAstFactory.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using JetBrains.Annotations;
 
 namespace ClosedXML.Parser;
 
@@ -15,6 +16,7 @@ namespace ClosedXML.Parser;
 /// <typeparam name="TScalarValue">Type of a scalar value used across expressions.</typeparam>
 /// <typeparam name="TNode">Type of a node used in the AST.</typeparam>
 /// <typeparam name="TContext">A context of the parsing. It's passed to every factory method and can contain global info that doesn't belong individual nodes.</typeparam>
+[PublicAPI]
 public interface IAstFactory<TScalarValue, TNode, in TContext>
 {
     /// <summary>

--- a/src/ClosedXML.Parser/StringBuilderExtensions.cs
+++ b/src/ClosedXML.Parser/StringBuilderExtensions.cs
@@ -78,6 +78,24 @@ internal static class StringBuilderExtensions
         return sb;
     }
 
+    public static StringBuilder AppendStartFragment(this StringBuilder sb, TransformContext ctx, SymbolRange symbolRange, TransformedSymbol nestedNode)
+    {
+        var formula = ctx.Formula;
+        for (var i = symbolRange.Start; i < nestedNode.OriginalRange.Start; ++i)
+            sb.Append(formula[i]);
+
+        return sb;
+    }
+
+    public static StringBuilder AppendEndFragment(this StringBuilder sb, TransformContext ctx, SymbolRange symbolRange, TransformedSymbol nestedNode)
+    {
+        var formula = ctx.Formula;
+        for (var i = nestedNode.OriginalRange.End; i < symbolRange.End; ++i)
+            sb.Append(formula[i]);
+
+        return sb;
+    }
+
 #if NETSTANDARD2_0
     /// <summary>
     /// Compatibility method for NETStandard 2.0, which doesn't have methods with <c>Span</c> arguments.

--- a/src/ClosedXML.Parser/TransformedSymbol.cs
+++ b/src/ClosedXML.Parser/TransformedSymbol.cs
@@ -9,9 +9,6 @@ internal readonly struct TransformedSymbol
 {
     private readonly string _formulaText;
 
-    /// <summary>
-    /// Range of the symbol in original formula.
-    /// </summary>
     private readonly SymbolRange _range;
 
     /// <summary>
@@ -27,9 +24,14 @@ internal readonly struct TransformedSymbol
     }
 
     /// <summary>
+    /// Range of the symbol in original formula.
+    /// </summary>
+    internal SymbolRange OriginalRange => _range;
+
+    /// <summary>
     /// Length of the transformed symbol.
     /// </summary>
-    public int Length => _transformedText?.Length ?? _range.End - _range.Start;
+    internal int Length => _transformedText?.Length ?? _range.End - _range.Start;
 
     /// <summary>
     /// There was no transformation of the symbol.
@@ -37,7 +39,7 @@ internal readonly struct TransformedSymbol
     /// <param name="formula">Text of whole formula.</param>
     /// <param name="range">Range of the symbol in the formula.</param>
     /// <param name="transformedSymbol">The string of a transformed symbol.</param>
-    public static TransformedSymbol ToText(string formula, SymbolRange range, string transformedSymbol)
+    internal static TransformedSymbol ToText(string formula, SymbolRange range, string transformedSymbol)
     {
         return new TransformedSymbol(formula, transformedSymbol, range);
     }
@@ -47,12 +49,12 @@ internal readonly struct TransformedSymbol
     /// </summary>
     /// <param name="formula">Text of whole formula.</param>
     /// <param name="range">Range of the symbol in the formula.</param>
-    public static TransformedSymbol CopyOriginal(string formula, SymbolRange range)
+    internal static TransformedSymbol CopyOriginal(string formula, SymbolRange range)
     {
         return new TransformedSymbol(formula, null, range);
     }
 
-    public ReadOnlySpan<char> AsSpan()
+    internal ReadOnlySpan<char> AsSpan()
     {
         if (_transformedText is not null)
             return _transformedText.AsSpan();

--- a/src/ClosedXML.Parser/TransformedSymbol.cs
+++ b/src/ClosedXML.Parser/TransformedSymbol.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text;
 
 namespace ClosedXML.Parser;
 
@@ -61,4 +62,16 @@ internal readonly struct TransformedSymbol
 
         return _formulaText.AsSpan(_range.Start, _range.End - _range.Start);
     }
-};
+
+    internal string ToString(ReadOnlySpan<char> append)
+    {
+        if (append.Length == 0 && _transformedText is not null)
+            return _transformedText;
+
+        var text = AsSpan();
+        return new StringBuilder(text.Length + append.Length)
+            .Append(text)
+            .Append(append)
+            .ToString();
+    }
+}


### PR DESCRIPTION
Ensure that during A1<-> R1C1 conversion, the whitespaces are kept, e.g. `(DATE(2017, 10, 3) - E4) / 365` used to be converted to `(DATE(2017,10,3)-R[3]R[3])/365` (old state) instead of `(DATE(2017, 10, 3) - R[3]R[3]) / 365`.