### PR TITLE
R1C1 -> A1 conversion results in #REF! when out of bounds

### DIFF
--- a/src/ClosedXML.Parser.Tests/FormulaConverterToA1Tests.cs
+++ b/src/ClosedXML.Parser.Tests/FormulaConverterToA1Tests.cs
@@ -20,4 +20,35 @@ public class FormulaConverterToA1Tests
     {
         Assert.Equal(a1, FormulaConverter.ToA1(r1c1, row, col));
     }
+
+    [Theory]
+    [InlineData("R[-4]C", 4, 1, "#REF!")]
+    [InlineData("R[1048575]C", 2, 1, "#REF!")]
+    [InlineData("RC[-4]", 1, 4, "#REF!")]
+    [InlineData("RC[5]", 1, 16380, "#REF!")]
+    public void Out_of_bounds_references(string r1c1, int row, int col, string a1)
+    {
+        Assert.Equal(a1, FormulaConverter.ToA1(r1c1, row, col));
+    }
+
+    [Theory]
+    [InlineData("C2:C4", 1, 1, "$B:$D")]
+    [InlineData("C[-2]:C4", 1, 4, "B:$D")]
+    [InlineData("C2:C[3]", 1, 4, "$B:G")]
+    [InlineData("C[2]:C[3]", 1, 4, "F:G")]
+    public void Columns_reference(string r1c1, int row, int col, string a1)
+    {
+        Assert.Equal(a1, FormulaConverter.ToA1(r1c1, row, col));
+    }
+
+    [Theory]
+    [InlineData("R2:R4", 1, 1, "$2:$4")]
+    [InlineData("R[-2]:R4", 4, 1, "2:$4")]
+    [InlineData("R2:R[3]", 4, 1, "$2:7")]
+    [InlineData("R[2]:R[3]", 4, 1, "6:7")]
+    public void Rows_reference(string r1c1, int row, int col, string a1)
+    {
+        Assert.Equal(a1, FormulaConverter.ToA1(r1c1, row, col));
+    }
+
 }

--- a/src/ClosedXML.Parser.Tests/FormulaConverterToR1C1Tests.cs
+++ b/src/ClosedXML.Parser.Tests/FormulaConverterToR1C1Tests.cs
@@ -218,5 +218,4 @@ public class FormulaConverterToR1C1Tests
     {
         Assert.Equal(r1c1, FormulaConverter.ToR1C1(a1, row, col));
     }
-
 }

--- a/src/ClosedXML.Parser.Tests/Lexers/A1CellTokenTests.cs
+++ b/src/ClosedXML.Parser.Tests/Lexers/A1CellTokenTests.cs
@@ -18,9 +18,9 @@ public class A1CellTokenTests
         // Check A1_CELL path
         AssertAreaReferenceToken("$B$3", new ReferenceArea(Absolute, 3, Absolute, 2, A1));
         AssertAreaReferenceToken("A1", new ReferenceArea(Relative, 1, Relative, 1, A1));
-        AssertAreaReferenceToken("XFD1", new ReferenceArea(Relative, 1, Relative, 16384, A1));
-        AssertAreaReferenceToken("A1048576", new ReferenceArea(Relative, 1048576, Relative, 1, A1));
-        AssertAreaReferenceToken("$XFD$1048576", new ReferenceArea(Absolute, 1048576, Absolute, 16384, A1));
+        AssertAreaReferenceToken("XFD1", new ReferenceArea(Relative, 1, Relative, RowCol.MaxCol, A1));
+        AssertAreaReferenceToken("A1048576", new ReferenceArea(Relative, RowCol.MaxRow, Relative, 1, A1));
+        AssertAreaReferenceToken("$XFD$1048576", new ReferenceArea(Absolute, RowCol.MaxRow, Absolute, RowCol.MaxCol, A1));
     }
 
     private static void AssertAreaReferenceToken(string token, ReferenceArea expectedReference)

--- a/src/ClosedXML.Parser.Tests/Lexers/A1SpanReferenceTokenTests.cs
+++ b/src/ClosedXML.Parser.Tests/Lexers/A1SpanReferenceTokenTests.cs
@@ -11,28 +11,25 @@
 /// </summary>
 public class A1SpanReferenceTokenTests
 {
-    private const int MaxCol = 16384;
-    private const int MaxRow = 1048576;
-
     [Fact]
     public void Parse_row_range()
     {
         // Check A1_ROW ':' A1_ROW path
-        AssertAreaReferenceToken("1:1", new ReferenceArea(new RowCol(false, 1, true, 1, A1), new RowCol(false, 1, true, MaxCol, A1)));
-        AssertAreaReferenceToken("$5:10", new ReferenceArea(new RowCol(true, 5, true, 1, A1), new RowCol(false, 10, true, MaxCol, A1)));
-        AssertAreaReferenceToken("7:$3", new ReferenceArea(new RowCol(false, 7, true, 1, A1), new RowCol(true, 3, true, MaxCol, A1)));
-        AssertAreaReferenceToken("$1048576:$1048576", new ReferenceArea(new RowCol(true, 1048576, true, 1, A1), new RowCol(true, 1048576, true, MaxCol, A1)));
+        AssertAreaReferenceToken("1:1", new ReferenceArea(new RowCol(false, 1, true, 1, A1), new RowCol(false, 1, true, RowCol.MaxCol, A1)));
+        AssertAreaReferenceToken("$5:10", new ReferenceArea(new RowCol(true, 5, true, 1, A1), new RowCol(false, 10, true, RowCol.MaxCol, A1)));
+        AssertAreaReferenceToken("7:$3", new ReferenceArea(new RowCol(false, 7, true, 1, A1), new RowCol(true, 3, true, RowCol.MaxCol, A1)));
+        AssertAreaReferenceToken("$1048576:$1048576", new ReferenceArea(new RowCol(true, RowCol.MaxRow, true, 1, A1), new RowCol(true, RowCol.MaxRow, true, RowCol.MaxCol, A1)));
     }
 
     [Fact]
     public void Parse_column_range()
     {
         // Check A1_COLUMN ':' A1_COLUMN path
-        AssertAreaReferenceToken("A:A", new ReferenceArea(new RowCol(true, 1, false, 1, A1), new RowCol(true, MaxRow, false, 1, A1)));
-        AssertAreaReferenceToken("RW:ST", new ReferenceArea(new RowCol(true, 1, false, 491, A1), new RowCol(true, MaxRow, false, 514, A1)));
-        AssertAreaReferenceToken("$C:D", new ReferenceArea(new RowCol(true, 1, true, 3, A1), new RowCol(true, MaxRow, false, 4, A1)));
-        AssertAreaReferenceToken("E:$C", new ReferenceArea(new RowCol(true, 1, false, 5, A1), new RowCol(true, MaxRow, true, 3, A1)));
-        AssertAreaReferenceToken("$XFD:$XFD", new ReferenceArea(new RowCol(true, 1, true, MaxCol, A1), new RowCol(true, MaxRow, true, MaxCol, A1)));
+        AssertAreaReferenceToken("A:A", new ReferenceArea(new RowCol(true, 1, false, 1, A1), new RowCol(true, RowCol.MaxRow, false, 1, A1)));
+        AssertAreaReferenceToken("RW:ST", new ReferenceArea(new RowCol(true, 1, false, 491, A1), new RowCol(true, RowCol.MaxRow, false, 514, A1)));
+        AssertAreaReferenceToken("$C:D", new ReferenceArea(new RowCol(true, 1, true, 3, A1), new RowCol(true, RowCol.MaxRow, false, 4, A1)));
+        AssertAreaReferenceToken("E:$C", new ReferenceArea(new RowCol(true, 1, false, 5, A1), new RowCol(true, RowCol.MaxRow, true, 3, A1)));
+        AssertAreaReferenceToken("$XFD:$XFD", new ReferenceArea(new RowCol(true, 1, true, RowCol.MaxCol, A1), new RowCol(true, RowCol.MaxRow, true, RowCol.MaxCol, A1)));
     }
     
     private static void AssertAreaReferenceToken(string token, ReferenceArea expectedReference)

--- a/src/ClosedXML.Parser.Tests/RowColTests.cs
+++ b/src/ClosedXML.Parser.Tests/RowColTests.cs
@@ -33,6 +33,8 @@ public class RowColTests
     public void ToA1_loops_for_out_of_bounds_reference(string r1c1, int row, int col, string a1)
     {
         // In GUI, Excel loops over, if user enters out-of-bounds reference to a formula.
-        Assert.Equal(a1, FormulaConverter.ToA1(r1c1, row, col));
+        var refR1C1 = TokenParser.ParseReference(r1c1, false).First;
+        var refA1 = TokenParser.ParseReference(a1, true).First;
+        Assert.Equal(refA1, refR1C1.ToA1(row, col));
     }
 }

--- a/src/ClosedXML.Parser.Tests/RowColTests.cs
+++ b/src/ClosedXML.Parser.Tests/RowColTests.cs
@@ -15,4 +15,24 @@ public class RowColTests
         Assert.Equal(1, a.RowValue);
         Assert.Equal(A1, a.Style);
     }
+
+    [Theory]
+    [InlineData("RC", 1, 1, "A1")]
+    [InlineData("RC[-5]", 1, 4, "XFC1")]
+    [InlineData("RC[-4]", 1, 4, "XFD1")]
+    [InlineData("RC[-3]", 1, 4, "A1")]
+    [InlineData("RC[2]", 1, 16382, "XFD1")]
+    [InlineData("RC[3]", 1, 16382, "A1")]
+    [InlineData("RC[4]", 1, 16382, "B1")]
+    [InlineData("R[0]C", 1, 1, "A1")]
+    [InlineData("R[-3]C", 4, 1, "A1")]
+    [InlineData("R[-4]C", 4, 1, "A1048576")]
+    [InlineData("R[-5]C", 4, 1, "A1048575")]
+    [InlineData("R[1]C", 1048575, 1, "A1048576")]
+    [InlineData("R[2]C", 1048575, 1, "A1")]
+    public void ToA1_loops_for_out_of_bounds_reference(string r1c1, int row, int col, string a1)
+    {
+        // In GUI, Excel loops over, if user enters out-of-bounds reference to a formula.
+        Assert.Equal(a1, FormulaConverter.ToA1(r1c1, row, col));
+    }
 }

--- a/src/ClosedXML.Parser.Tests/Rules/CellReferenceRuleTests.cs
+++ b/src/ClosedXML.Parser.Tests/Rules/CellReferenceRuleTests.cs
@@ -7,9 +7,6 @@ namespace ClosedXML.Parser.Tests.Rules;
 /// </summary>
 public class CellReferenceRuleTests
 {
-    private const int MaxCol = 16384;
-    private const int MaxRow = 1048576;
-
     [Theory]
     [MemberData(nameof(TokenCombinationsA1))]
     public void A1_possible_token_combinations_are_converted_to_node(string formula, AstNode expectedNode)
@@ -52,8 +49,8 @@ public class CellReferenceRuleTests
                 "$XFC$1048575:$XFD$1048576",
                 new ReferenceNode(
                     new ReferenceArea(
-                        new RowCol(true, MaxRow - 1, true, MaxCol - 1, A1),
-                        new RowCol(true, MaxRow, true, MaxCol, A1)))
+                        new RowCol(true, RowCol.MaxRow - 1, true, RowCol.MaxCol - 1, A1),
+                        new RowCol(true, RowCol.MaxRow, true, RowCol.MaxCol, A1)))
             };
 
             // "MS-XLSX 2.2.2.1: The formula MUST NOT use the bang-reference or bang-name.

--- a/src/ClosedXML.Parser/FormulaConverter.cs
+++ b/src/ClosedXML.Parser/FormulaConverter.cs
@@ -54,12 +54,12 @@ public static class FormulaConverter
 
     private class TextVisitorR1C1 : FormulaGeneratorVisitor
     {
-        protected override ReferenceArea ModifyRef(TransformContext ctx, ReferenceArea reference)
+        protected override ReferenceArea? ModifyRef(TransformContext ctx, ReferenceArea reference)
         {
             return reference.ToR1C1(ctx.Row, ctx.Col);
         }
 
-        protected override RowCol ModifyCellFunction(TransformContext ctx, RowCol cell)
+        protected override RowCol? ModifyCellFunction(TransformContext ctx, RowCol cell)
         {
             return cell.ToR1C1(ctx.Row, ctx.Col);
         }
@@ -67,12 +67,12 @@ public static class FormulaConverter
 
     private class TextVisitorA1 : FormulaGeneratorVisitor
     {
-        protected override ReferenceArea ModifyRef(TransformContext ctx, ReferenceArea reference)
+        protected override ReferenceArea? ModifyRef(TransformContext ctx, ReferenceArea reference)
         {
             return reference.ToA1(ctx.Row, ctx.Col);
         }
 
-        protected override RowCol ModifyCellFunction(TransformContext ctx, RowCol cell)
+        protected override RowCol? ModifyCellFunction(TransformContext ctx, RowCol cell)
         {
             return cell.ToA1(ctx.Row, ctx.Col);
         }

--- a/src/ClosedXML.Parser/FormulaConverter.cs
+++ b/src/ClosedXML.Parser/FormulaConverter.cs
@@ -69,12 +69,12 @@ public static class FormulaConverter
     {
         protected override ReferenceArea? ModifyRef(TransformContext ctx, ReferenceArea reference)
         {
-            return reference.ToA1(ctx.Row, ctx.Col);
+            return reference.ToA1OrError(ctx.Row, ctx.Col);
         }
 
         protected override RowCol? ModifyCellFunction(TransformContext ctx, RowCol cell)
         {
-            return cell.ToA1(ctx.Row, ctx.Col);
+            return cell.ToA1OrError(ctx.Row, ctx.Col);
         }
     }
 }

--- a/src/ClosedXML.Parser/FormulaGeneratorVisitor.cs
+++ b/src/ClosedXML.Parser/FormulaGeneratorVisitor.cs
@@ -414,8 +414,8 @@ internal class FormulaGeneratorVisitor : IAstFactory<TransformedSymbol, Transfor
     /// </summary>
     /// <param name="ctx">The origin of formula.</param>
     /// <param name="reference">Area reference.</param>
-    /// <returns>Modified reference.</returns>
-    protected virtual ReferenceArea ModifyRef(TransformContext ctx, ReferenceArea reference)
+    /// <returns>Modified reference or null if <c>#REF!</c>.</returns>
+    protected virtual ReferenceArea? ModifyRef(TransformContext ctx, ReferenceArea reference)
     {
         return reference;
     }
@@ -425,8 +425,8 @@ internal class FormulaGeneratorVisitor : IAstFactory<TransformedSymbol, Transfor
     /// </summary>
     /// <param name="ctx">The transformation context.</param>
     /// <param name="cell">Original cell containing function.</param>
-    /// <returns>Modified reference.</returns>
-    protected virtual RowCol ModifyCellFunction(TransformContext ctx, RowCol cell)
+    /// <returns>Modified reference or null if <c>#REF!</c>.</returns>
+    protected virtual RowCol? ModifyCellFunction(TransformContext ctx, RowCol cell)
     {
         return cell;
     }

--- a/src/ClosedXML.Parser/ReferenceArea.cs
+++ b/src/ClosedXML.Parser/ReferenceArea.cs
@@ -129,16 +129,17 @@ public readonly struct ReferenceArea
     /// Convert R1C1 reference to A1.
     /// </summary>
     /// <remarks>Assumes reference is in R1C1.</remarks>
-    internal ReferenceArea ToA1(int anchorRow, int anchorCol)
+    internal ReferenceArea? ToA1OrError(int anchorRow, int anchorCol)
     {
-        var first = First.ToA1(anchorRow, anchorCol);
-        if (First != Second)
-        {
-            var second = Second.ToA1(anchorRow, anchorCol);
-            return new ReferenceArea(first, second);
-        }
+        var first = First.ToA1OrError(anchorRow, anchorCol);
+        if (first is null)
+            return null;
 
-        return new ReferenceArea(first, first);
+        var second = First != Second ? Second.ToA1OrError(anchorRow, anchorCol) : first;
+        if (second is null)
+            return null;
+
+        return new ReferenceArea(first.Value, second.Value);
     }
 
     internal StringBuilder Append(StringBuilder sb)

--- a/src/ClosedXML.Parser/RowCol.cs
+++ b/src/ClosedXML.Parser/RowCol.cs
@@ -31,6 +31,9 @@ namespace ClosedXML.Parser;
 /// </summary>
 public readonly struct RowCol : IEquatable<RowCol>
 {
+    internal const int MaxRow = 1048576;
+    internal const int MaxCol = 16384;
+
     // keep at 0, so default ctor creates is A1
     private readonly int _rowIndex;
     private readonly int _columnIndex;
@@ -171,10 +174,10 @@ public readonly struct RowCol : IEquatable<RowCol>
     /// <exception cref="ArgumentOutOfRangeException">Row or col is out of valid row or column number.</exception>
     public RowCol ToR1C1(int anchorRow, int anchorCol)
     {
-        if (anchorRow is < 1 or > 1048576)
+        if (anchorRow is < 1 or > MaxRow)
             throw new ArgumentOutOfRangeException(nameof(anchorRow));
 
-        if (anchorCol is < 1 or > 16384)
+        if (anchorCol is < 1 or > MaxCol)
             throw new ArgumentOutOfRangeException(nameof(anchorCol));
 
         if (IsR1C1)
@@ -207,10 +210,10 @@ public readonly struct RowCol : IEquatable<RowCol>
     /// <exception cref="ArgumentOutOfRangeException">Row or col is out of valid row or column number.</exception>
     public RowCol ToA1(int anchorRow, int anchorCol)
     {
-        if (anchorRow is < 1 or > 1048576)
+        if (anchorRow is < 1 or > MaxRow)
             throw new ArgumentOutOfRangeException(nameof(anchorRow));
 
-        if (anchorCol is < 1 or > 16384)
+        if (anchorCol is < 1 or > MaxCol)
             throw new ArgumentOutOfRangeException(nameof(anchorCol));
 
         if (IsA1)

--- a/src/ClosedXML.Parser/RowCol.cs
+++ b/src/ClosedXML.Parser/RowCol.cs
@@ -235,6 +235,18 @@ public readonly struct RowCol : IEquatable<RowCol>
         return new RowCol(RowType, newRowPosition, ColumnType, newColPosition, A1);
     }
 
+    internal RowCol? ToA1OrError(int anchorRow, int anchorCol)
+    {
+        var (newRowPosition, newColPosition) = ToA1Positions(anchorRow, anchorCol);
+        if (RowType == Relative && newRowPosition is < 1 or > MaxRow)
+            return null;
+
+        if (ColumnType == Relative && newColPosition is < 1 or > MaxCol)
+            return null;
+
+        return new RowCol(RowType, newRowPosition, ColumnType, newColPosition, A1);
+    }
+
     private (int Row, int Col) ToA1Positions(int anchorRow, int anchorCol)
     {
         if (anchorRow is < 1 or > MaxRow)

--- a/src/ClosedXML.Parser/StringBuilderExtensions.cs
+++ b/src/ClosedXML.Parser/StringBuilderExtensions.cs
@@ -50,15 +50,17 @@ internal static class StringBuilderExtensions
         return sb.Append(functionName).AppendArguments(ctx, range, arguments);
     }
 
-    public static StringBuilder AppendRef(this StringBuilder sb, ReferenceArea reference)
+    public static StringBuilder AppendRef(this StringBuilder sb, ReferenceArea? reference)
     {
-        reference.Append(sb);
-        return sb;
+        return reference is null ? sb.Append("#REF!") : reference.Value.Append(sb);
     }
 
-    public static StringBuilder AppendRef(this StringBuilder sb, RowCol rowCol)
+    public static StringBuilder AppendRef(this StringBuilder sb, RowCol? rowCol)
     {
-        rowCol.Append(sb);
+        if (rowCol is null)
+            return sb.Append("#REF!");
+
+        rowCol.Value.Append(sb);
         return sb;
     }
 

--- a/src/ClosedXML.Parser/TokenParser.cs
+++ b/src/ClosedXML.Parser/TokenParser.cs
@@ -5,9 +5,6 @@ namespace ClosedXML.Parser;
 
 internal static class TokenParser
 {
-    private const int MaxCol = 16384;
-    private const int MaxRow = 1048576;
-
     /// <summary>
     /// Parse <see cref="Token.SINGLE_SHEET_PREFIX"/> token.
     /// </summary>
@@ -256,7 +253,7 @@ internal static class TokenParser
             var row2 = ReadRow(input, ref i);
             return new ReferenceArea(
                 new RowCol(abs1, row1, true, 1, A1),
-                new RowCol(absRow2, row2, true, MaxCol, A1));
+                new RowCol(absRow2, row2, true, RowCol.MaxCol, A1));
         }
 
         var col = ReadColumn(input, ref i);
@@ -271,7 +268,7 @@ internal static class TokenParser
             var col2 = ReadColumn(input, ref i);
             return new ReferenceArea(
                 new RowCol(true, 1, abs1, col, A1),
-                new RowCol(true, MaxRow, absCol2, col2, A1));
+                new RowCol(true, RowCol.MaxRow, absCol2, col2, A1));
         }
 
         var secondAbsolute = IsAbsolute(input, i);

--- a/src/ClosedXML.Parser/TransformContext.cs
+++ b/src/ClosedXML.Parser/TransformContext.cs
@@ -1,17 +1,31 @@
-﻿namespace ClosedXML.Parser;
+﻿using System;
+
+namespace ClosedXML.Parser;
 
 internal sealed class TransformContext
 {
-    public TransformContext(string formula, int row, int col)
+    internal TransformContext(string formula, int row, int col)
     {
+        if (row is < 1 or > RowCol.MaxRow)
+            throw new ArgumentOutOfRangeException(nameof(row));
+
+        if (col is < 1 or > RowCol.MaxCol)
+            throw new ArgumentOutOfRangeException(nameof(row));
+
         Formula = formula;
         Row = row;
         Col = col;
     }
 
-    public string Formula { get; }
-    
-    public int Row { get; } 
-    
-    public int Col { get; }
+    internal string Formula { get; }
+
+    /// <summary>
+    /// Absolute row number in a sheet.
+    /// </summary>
+    internal int Row { get; }
+
+    /// <summary>
+    /// Absolute column number in a sheet.
+    /// </summary>
+    internal int Col { get; }
 }


### PR DESCRIPTION
When R1C1 is converted to A1, the converted reference can be out of sheet bounds, e.g. R[-10]C1 at R1C1 would be out of bounds and should results in #REF! error.