### PR TITLE
Accept references with deleted parts (Sheet!#REF!, #REF!A1 or #REF!#REF!)

### DIFF
--- a/src/ClosedXML.ANTLR/FormulaParser.cs
+++ b/src/ClosedXML.ANTLR/FormulaParser.cs
@@ -978,7 +978,13 @@ public partial class FormulaParser : Parser {
 	}
 
 	public partial class Ref_atom_expressionContext : ParserRuleContext {
-		[System.Diagnostics.DebuggerNonUserCode] public ITerminalNode REF_CONSTANT() { return GetToken(FormulaParser.REF_CONSTANT, 0); }
+		[System.Diagnostics.DebuggerNonUserCode] public ITerminalNode[] REF_CONSTANT() { return GetTokens(FormulaParser.REF_CONSTANT); }
+		[System.Diagnostics.DebuggerNonUserCode] public ITerminalNode REF_CONSTANT(int i) {
+			return GetToken(FormulaParser.REF_CONSTANT, i);
+		}
+		[System.Diagnostics.DebuggerNonUserCode] public A1_referenceContext a1_reference() {
+			return GetRuleContext<A1_referenceContext>(0);
+		}
 		[System.Diagnostics.DebuggerNonUserCode] public ITerminalNode OPEN_BRACE() { return GetToken(FormulaParser.OPEN_BRACE, 0); }
 		[System.Diagnostics.DebuggerNonUserCode] public Ref_expressionContext ref_expression() {
 			return GetRuleContext<Ref_expressionContext>(0);
@@ -1008,52 +1014,91 @@ public partial class FormulaParser : Parser {
 		Ref_atom_expressionContext _localctx = new Ref_atom_expressionContext(Context, State);
 		EnterRule(_localctx, 28, RULE_ref_atom_expression);
 		try {
-			State = 176;
+			State = 180;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,13,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,14,Context) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
 				State = 167;
 				Match(REF_CONSTANT);
+				State = 170;
+				ErrorHandler.Sync(this);
+				switch (TokenStream.LA(1)) {
+				case A1_CELL:
+				case A1_SPAN_REFERENCE:
+					{
+					State = 168;
+					a1_reference();
+					}
+					break;
+				case REF_CONSTANT:
+					{
+					State = 169;
+					Match(REF_CONSTANT);
+					}
+					break;
+				case Eof:
+				case POW:
+				case MULT:
+				case DIV:
+				case PLUS:
+				case MINUS:
+				case CONCAT:
+				case EQUAL:
+				case NOT_EQUAL:
+				case LESS_OR_EQUAL_THAN:
+				case LESS_THAN:
+				case GREATER_OR_EQUAL_THAN:
+				case GREATER_THAN:
+				case PERCENT:
+				case COLON:
+				case CLOSE_BRACE:
+				case COMMA:
+				case SPACE:
+				case SPILL:
+					break;
+				default:
+					break;
+				}
 				}
 				break;
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 168;
+				State = 172;
 				Match(OPEN_BRACE);
-				State = 169;
+				State = 173;
 				ref_expression();
-				State = 170;
+				State = 174;
 				Match(CLOSE_BRACE);
 				}
 				break;
 			case 3:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 172;
+				State = 176;
 				cell_reference();
 				}
 				break;
 			case 4:
 				EnterOuterAlt(_localctx, 4);
 				{
-				State = 173;
+				State = 177;
 				ref_function_call();
 				}
 				break;
 			case 5:
 				EnterOuterAlt(_localctx, 5);
 				{
-				State = 174;
+				State = 178;
 				name_reference();
 				}
 				break;
 			case 6:
 				EnterOuterAlt(_localctx, 6);
 				{
-				State = 175;
+				State = 179;
 				structure_reference();
 				}
 				break;
@@ -1092,45 +1137,45 @@ public partial class FormulaParser : Parser {
 		ConstantContext _localctx = new ConstantContext(Context, State);
 		EnterRule(_localctx, 30, RULE_constant);
 		try {
-			State = 186;
+			State = 190;
 			ErrorHandler.Sync(this);
 			switch (TokenStream.LA(1)) {
 			case NONREF_ERRORS:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 178;
+				State = 182;
 				Match(NONREF_ERRORS);
 				}
 				break;
 			case LOGICAL_CONSTANT:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 179;
+				State = 183;
 				Match(LOGICAL_CONSTANT);
 				}
 				break;
 			case NUMERICAL_CONSTANT:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 180;
+				State = 184;
 				Match(NUMERICAL_CONSTANT);
 				}
 				break;
 			case STRING_CONSTANT:
 				EnterOuterAlt(_localctx, 4);
 				{
-				State = 181;
+				State = 185;
 				Match(STRING_CONSTANT);
 				}
 				break;
 			case OPEN_CURLY:
 				EnterOuterAlt(_localctx, 5);
 				{
-				State = 182;
+				State = 186;
 				Match(OPEN_CURLY);
-				State = 183;
+				State = 187;
 				constant_list_rows();
-				State = 184;
+				State = 188;
 				Match(CLOSE_CURLY);
 				}
 				break;
@@ -1175,21 +1220,21 @@ public partial class FormulaParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 188;
+			State = 192;
 			constant_list_row();
-			State = 193;
+			State = 197;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			while (_la==SEMICOLON) {
 				{
 				{
-				State = 189;
+				State = 193;
 				Match(SEMICOLON);
-				State = 190;
+				State = 194;
 				constant_list_row();
 				}
 				}
-				State = 195;
+				State = 199;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 			}
@@ -1236,7 +1281,7 @@ public partial class FormulaParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 198;
+			State = 202;
 			ErrorHandler.Sync(this);
 			switch (TokenStream.LA(1)) {
 			case NONREF_ERRORS:
@@ -1245,28 +1290,28 @@ public partial class FormulaParser : Parser {
 			case STRING_CONSTANT:
 			case OPEN_CURLY:
 				{
-				State = 196;
+				State = 200;
 				constant();
 				}
 				break;
 			case REF_CONSTANT:
 				{
-				State = 197;
+				State = 201;
 				Match(REF_CONSTANT);
 				}
 				break;
 			default:
 				throw new NoViableAltException(this);
 			}
-			State = 207;
+			State = 211;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			while (_la==COMMA) {
 				{
 				{
-				State = 200;
+				State = 204;
 				Match(COMMA);
-				State = 203;
+				State = 207;
 				ErrorHandler.Sync(this);
 				switch (TokenStream.LA(1)) {
 				case NONREF_ERRORS:
@@ -1275,13 +1320,13 @@ public partial class FormulaParser : Parser {
 				case STRING_CONSTANT:
 				case OPEN_CURLY:
 					{
-					State = 201;
+					State = 205;
 					constant();
 					}
 					break;
 				case REF_CONSTANT:
 					{
-					State = 202;
+					State = 206;
 					Match(REF_CONSTANT);
 					}
 					break;
@@ -1290,7 +1335,7 @@ public partial class FormulaParser : Parser {
 				}
 				}
 				}
-				State = 209;
+				State = 213;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 			}
@@ -1329,51 +1374,51 @@ public partial class FormulaParser : Parser {
 		Cell_referenceContext _localctx = new Cell_referenceContext(Context, State);
 		EnterRule(_localctx, 36, RULE_cell_reference);
 		try {
-			State = 223;
+			State = 227;
 			ErrorHandler.Sync(this);
 			switch (TokenStream.LA(1)) {
 			case A1_CELL:
 			case A1_SPAN_REFERENCE:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 210;
+				State = 214;
 				a1_reference();
 				}
 				break;
 			case BANG_REFERENCE:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 211;
+				State = 215;
 				Match(BANG_REFERENCE);
 				}
 				break;
 			case SHEET_RANGE_PREFIX:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 212;
+				State = 216;
 				Match(SHEET_RANGE_PREFIX);
-				State = 213;
+				State = 217;
 				a1_reference();
 				}
 				break;
 			case SINGLE_SHEET_PREFIX:
 				EnterOuterAlt(_localctx, 4);
 				{
-				State = 214;
+				State = 218;
 				Match(SINGLE_SHEET_PREFIX);
-				State = 217;
+				State = 221;
 				ErrorHandler.Sync(this);
 				switch (TokenStream.LA(1)) {
 				case A1_CELL:
 				case A1_SPAN_REFERENCE:
 					{
-					State = 215;
+					State = 219;
 					a1_reference();
 					}
 					break;
 				case REF_CONSTANT:
 					{
-					State = 216;
+					State = 220;
 					Match(REF_CONSTANT);
 					}
 					break;
@@ -1385,13 +1430,13 @@ public partial class FormulaParser : Parser {
 			case NAME:
 				EnterOuterAlt(_localctx, 5);
 				{
-				State = 219;
+				State = 223;
 				Match(NAME);
-				State = 220;
+				State = 224;
 				Match(COLON);
-				State = 221;
+				State = 225;
 				Match(SINGLE_SHEET_PREFIX);
-				State = 222;
+				State = 226;
 				a1_reference();
 				}
 				break;
@@ -1429,31 +1474,31 @@ public partial class FormulaParser : Parser {
 		A1_referenceContext _localctx = new A1_referenceContext(Context, State);
 		EnterRule(_localctx, 38, RULE_a1_reference);
 		try {
-			State = 230;
+			State = 234;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,21,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,22,Context) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 225;
+				State = 229;
 				Match(A1_CELL);
 				}
 				break;
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 226;
+				State = 230;
 				Match(A1_CELL);
-				State = 227;
+				State = 231;
 				Match(COLON);
-				State = 228;
+				State = 232;
 				Match(A1_CELL);
 				}
 				break;
 			case 3:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 229;
+				State = 233;
 				Match(A1_SPAN_REFERENCE);
 				}
 				break;
@@ -1497,41 +1542,41 @@ public partial class FormulaParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 233;
+			State = 237;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & 1099119461950L) != 0)) {
 				{
-				State = 232;
+				State = 236;
 				arg_expression();
 				}
 			}
 
-			State = 241;
+			State = 245;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			while (_la==COMMA) {
 				{
 				{
-				State = 235;
+				State = 239;
 				Match(COMMA);
-				State = 237;
+				State = 241;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 				if ((((_la) & ~0x3f) == 0 && ((1L << _la) & 1099119461950L) != 0)) {
 					{
-					State = 236;
+					State = 240;
 					arg_expression();
 					}
 				}
 
 				}
 				}
-				State = 243;
+				State = 247;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 			}
-			State = 244;
+			State = 248;
 			Match(CLOSE_BRACE);
 			}
 		}
@@ -1592,15 +1637,15 @@ public partial class FormulaParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 246;
+			State = 250;
 			arg_concat_expression();
-			State = 251;
+			State = 255;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			while ((((_la) & ~0x3f) == 0 && ((1L << _la) & 258048L) != 0)) {
 				{
 				{
-				State = 247;
+				State = 251;
 				_la = TokenStream.LA(1);
 				if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & 258048L) != 0)) ) {
 				ErrorHandler.RecoverInline(this);
@@ -1609,11 +1654,11 @@ public partial class FormulaParser : Parser {
 					ErrorHandler.ReportMatch(this);
 				    Consume();
 				}
-				State = 248;
+				State = 252;
 				arg_concat_expression();
 				}
 				}
-				State = 253;
+				State = 257;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 			}
@@ -1656,21 +1701,21 @@ public partial class FormulaParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 254;
+			State = 258;
 			arg_additive_expression();
-			State = 259;
+			State = 263;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			while (_la==CONCAT) {
 				{
 				{
-				State = 255;
+				State = 259;
 				Match(CONCAT);
-				State = 256;
+				State = 260;
 				arg_additive_expression();
 				}
 				}
-				State = 261;
+				State = 265;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 			}
@@ -1717,15 +1762,15 @@ public partial class FormulaParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 262;
+			State = 266;
 			arg_multiplying_expression();
-			State = 267;
+			State = 271;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			while (_la==PLUS || _la==MINUS) {
 				{
 				{
-				State = 263;
+				State = 267;
 				_la = TokenStream.LA(1);
 				if ( !(_la==PLUS || _la==MINUS) ) {
 				ErrorHandler.RecoverInline(this);
@@ -1734,11 +1779,11 @@ public partial class FormulaParser : Parser {
 					ErrorHandler.ReportMatch(this);
 				    Consume();
 				}
-				State = 264;
+				State = 268;
 				arg_multiplying_expression();
 				}
 				}
-				State = 269;
+				State = 273;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 			}
@@ -1785,15 +1830,15 @@ public partial class FormulaParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 270;
+			State = 274;
 			arg_pow_expression();
-			State = 275;
+			State = 279;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			while (_la==MULT || _la==DIV) {
 				{
 				{
-				State = 271;
+				State = 275;
 				_la = TokenStream.LA(1);
 				if ( !(_la==MULT || _la==DIV) ) {
 				ErrorHandler.RecoverInline(this);
@@ -1802,11 +1847,11 @@ public partial class FormulaParser : Parser {
 					ErrorHandler.ReportMatch(this);
 				    Consume();
 				}
-				State = 272;
+				State = 276;
 				arg_pow_expression();
 				}
 				}
-				State = 277;
+				State = 281;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 			}
@@ -1849,21 +1894,21 @@ public partial class FormulaParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 278;
+			State = 282;
 			arg_percent_expression();
-			State = 283;
+			State = 287;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			while (_la==POW) {
 				{
 				{
-				State = 279;
+				State = 283;
 				Match(POW);
-				State = 280;
+				State = 284;
 				arg_percent_expression();
 				}
 				}
-				State = 285;
+				State = 289;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 			}
@@ -1900,14 +1945,14 @@ public partial class FormulaParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 286;
+			State = 290;
 			arg_prefix_atom_expression();
-			State = 288;
+			State = 292;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			if (_la==PERCENT) {
 				{
-				State = 287;
+				State = 291;
 				Match(PERCENT);
 				}
 			}
@@ -1947,14 +1992,14 @@ public partial class FormulaParser : Parser {
 		EnterRule(_localctx, 54, RULE_arg_prefix_atom_expression);
 		int _la;
 		try {
-			State = 293;
+			State = 297;
 			ErrorHandler.Sync(this);
 			switch (TokenStream.LA(1)) {
 			case PLUS:
 			case MINUS:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 290;
+				State = 294;
 				_la = TokenStream.LA(1);
 				if ( !(_la==PLUS || _la==MINUS) ) {
 				ErrorHandler.RecoverInline(this);
@@ -1963,7 +2008,7 @@ public partial class FormulaParser : Parser {
 					ErrorHandler.ReportMatch(this);
 				    Consume();
 				}
-				State = 291;
+				State = 295;
 				arg_prefix_atom_expression();
 				}
 				break;
@@ -1988,7 +2033,7 @@ public partial class FormulaParser : Parser {
 			case INTRA_TABLE_REFERENCE:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 292;
+				State = 296;
 				arg_atom_expression();
 				}
 				break;
@@ -2034,38 +2079,38 @@ public partial class FormulaParser : Parser {
 		Arg_atom_expressionContext _localctx = new Arg_atom_expressionContext(Context, State);
 		EnterRule(_localctx, 56, RULE_arg_atom_expression);
 		try {
-			State = 302;
+			State = 306;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,32,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,33,Context) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 295;
+				State = 299;
 				constant();
 				}
 				break;
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 296;
+				State = 300;
 				Match(OPEN_BRACE);
-				State = 297;
+				State = 301;
 				expression();
-				State = 298;
+				State = 302;
 				Match(CLOSE_BRACE);
 				}
 				break;
 			case 3:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 300;
+				State = 304;
 				function_call();
 				}
 				break;
 			case 4:
 				EnterOuterAlt(_localctx, 4);
 				{
-				State = 301;
+				State = 305;
 				ref_implicit_expression();
 				}
 				break;
@@ -2099,13 +2144,13 @@ public partial class FormulaParser : Parser {
 		EnterRule(_localctx, 58, RULE_name_reference);
 		int _la;
 		try {
-			State = 307;
+			State = 311;
 			ErrorHandler.Sync(this);
 			switch (TokenStream.LA(1)) {
 			case NAME:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 304;
+				State = 308;
 				Match(NAME);
 				}
 				break;
@@ -2113,7 +2158,7 @@ public partial class FormulaParser : Parser {
 			case SINGLE_SHEET_PREFIX:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 305;
+				State = 309;
 				_la = TokenStream.LA(1);
 				if ( !(_la==BOOK_PREFIX || _la==SINGLE_SHEET_PREFIX) ) {
 				ErrorHandler.RecoverInline(this);
@@ -2122,7 +2167,7 @@ public partial class FormulaParser : Parser {
 					ErrorHandler.ReportMatch(this);
 				    Consume();
 				}
-				State = 306;
+				State = 310;
 				Match(NAME);
 				}
 				break;
@@ -2161,17 +2206,17 @@ public partial class FormulaParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 310;
+			State = 314;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			if (_la==BOOK_PREFIX || _la==NAME) {
 				{
-				State = 309;
+				State = 313;
 				table_identifier();
 				}
 			}
 
-			State = 312;
+			State = 316;
 			Match(INTRA_TABLE_REFERENCE);
 			}
 		}
@@ -2206,17 +2251,17 @@ public partial class FormulaParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 315;
+			State = 319;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			if (_la==BOOK_PREFIX) {
 				{
-				State = 314;
+				State = 318;
 				Match(BOOK_PREFIX);
 				}
 			}
 
-			State = 317;
+			State = 321;
 			table_name();
 			}
 		}
@@ -2247,7 +2292,7 @@ public partial class FormulaParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 319;
+			State = 323;
 			Match(NAME);
 			}
 		}
@@ -2281,9 +2326,9 @@ public partial class FormulaParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 321;
+			State = 325;
 			Match(REF_FUNCTION_LIST);
-			State = 322;
+			State = 326;
 			argument_list();
 			}
 		}
@@ -2321,12 +2366,12 @@ public partial class FormulaParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 329;
+			State = 333;
 			ErrorHandler.Sync(this);
 			switch (TokenStream.LA(1)) {
 			case CELL_FUNCTION_LIST:
 				{
-				State = 324;
+				State = 328;
 				Match(CELL_FUNCTION_LIST);
 				}
 				break;
@@ -2334,12 +2379,12 @@ public partial class FormulaParser : Parser {
 			case SINGLE_SHEET_PREFIX:
 			case USER_DEFINED_FUNCTION_NAME:
 				{
-				State = 326;
+				State = 330;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 				if (_la==BOOK_PREFIX || _la==SINGLE_SHEET_PREFIX) {
 					{
-					State = 325;
+					State = 329;
 					_la = TokenStream.LA(1);
 					if ( !(_la==BOOK_PREFIX || _la==SINGLE_SHEET_PREFIX) ) {
 					ErrorHandler.RecoverInline(this);
@@ -2351,14 +2396,14 @@ public partial class FormulaParser : Parser {
 					}
 				}
 
-				State = 328;
+				State = 332;
 				Match(USER_DEFINED_FUNCTION_NAME);
 				}
 				break;
 			default:
 				throw new NoViableAltException(this);
 			}
-			State = 331;
+			State = 335;
 			argument_list();
 			}
 		}
@@ -2374,7 +2419,7 @@ public partial class FormulaParser : Parser {
 	}
 
 	private static int[] _serializedATN = {
-		4,1,39,334,2,0,7,0,2,1,7,1,2,2,7,2,2,3,7,3,2,4,7,4,2,5,7,5,2,6,7,6,2,7,
+		4,1,39,338,2,0,7,0,2,1,7,1,2,2,7,2,2,3,7,3,2,4,7,4,2,5,7,5,2,6,7,6,2,7,
 		7,7,2,8,7,8,2,9,7,9,2,10,7,10,2,11,7,11,2,12,7,12,2,13,7,13,2,14,7,14,
 		2,15,7,15,2,16,7,16,2,17,7,17,2,18,7,18,2,19,7,19,2,20,7,20,2,21,7,21,
 		2,22,7,22,2,23,7,23,2,24,7,24,2,25,7,25,2,26,7,26,2,27,7,27,2,28,7,28,
@@ -2386,104 +2431,105 @@ public partial class FormulaParser : Parser {
 		8,1,8,1,8,1,8,3,8,133,8,8,1,9,1,9,1,9,5,9,138,8,9,10,9,12,9,141,9,9,1,
 		10,1,10,1,10,3,10,146,8,10,1,11,1,11,1,11,5,11,151,8,11,10,11,12,11,154,
 		9,11,1,12,1,12,1,12,5,12,159,8,12,10,12,12,12,162,9,12,1,13,1,13,3,13,
-		166,8,13,1,14,1,14,1,14,1,14,1,14,1,14,1,14,1,14,1,14,3,14,177,8,14,1,
-		15,1,15,1,15,1,15,1,15,1,15,1,15,1,15,3,15,187,8,15,1,16,1,16,1,16,5,16,
-		192,8,16,10,16,12,16,195,9,16,1,17,1,17,3,17,199,8,17,1,17,1,17,1,17,3,
-		17,204,8,17,5,17,206,8,17,10,17,12,17,209,9,17,1,18,1,18,1,18,1,18,1,18,
-		1,18,1,18,3,18,218,8,18,1,18,1,18,1,18,1,18,3,18,224,8,18,1,19,1,19,1,
-		19,1,19,1,19,3,19,231,8,19,1,20,3,20,234,8,20,1,20,1,20,3,20,238,8,20,
-		5,20,240,8,20,10,20,12,20,243,9,20,1,20,1,20,1,21,1,21,1,21,5,21,250,8,
-		21,10,21,12,21,253,9,21,1,22,1,22,1,22,5,22,258,8,22,10,22,12,22,261,9,
-		22,1,23,1,23,1,23,5,23,266,8,23,10,23,12,23,269,9,23,1,24,1,24,1,24,5,
-		24,274,8,24,10,24,12,24,277,9,24,1,25,1,25,1,25,5,25,282,8,25,10,25,12,
-		25,285,9,25,1,26,1,26,3,26,289,8,26,1,27,1,27,1,27,3,27,294,8,27,1,28,
-		1,28,1,28,1,28,1,28,1,28,1,28,3,28,303,8,28,1,29,1,29,1,29,3,29,308,8,
-		29,1,30,3,30,311,8,30,1,30,1,30,1,31,3,31,316,8,31,1,31,1,31,1,32,1,32,
-		1,33,1,33,1,33,1,34,1,34,3,34,327,8,34,1,34,3,34,330,8,34,1,34,1,34,1,
-		34,0,0,35,0,2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32,34,36,38,40,42,
-		44,46,48,50,52,54,56,58,60,62,64,66,68,0,4,1,0,12,17,1,0,9,10,1,0,7,8,
-		2,0,29,29,32,32,351,0,70,1,0,0,0,2,73,1,0,0,0,4,81,1,0,0,0,6,89,1,0,0,
-		0,8,97,1,0,0,0,10,105,1,0,0,0,12,113,1,0,0,0,14,123,1,0,0,0,16,132,1,0,
-		0,0,18,134,1,0,0,0,20,145,1,0,0,0,22,147,1,0,0,0,24,155,1,0,0,0,26,163,
-		1,0,0,0,28,176,1,0,0,0,30,186,1,0,0,0,32,188,1,0,0,0,34,198,1,0,0,0,36,
-		223,1,0,0,0,38,230,1,0,0,0,40,233,1,0,0,0,42,246,1,0,0,0,44,254,1,0,0,
-		0,46,262,1,0,0,0,48,270,1,0,0,0,50,278,1,0,0,0,52,286,1,0,0,0,54,293,1,
-		0,0,0,56,302,1,0,0,0,58,307,1,0,0,0,60,310,1,0,0,0,62,315,1,0,0,0,64,319,
-		1,0,0,0,66,321,1,0,0,0,68,329,1,0,0,0,70,71,3,2,1,0,71,72,5,0,0,1,72,1,
-		1,0,0,0,73,78,3,4,2,0,74,75,7,0,0,0,75,77,3,4,2,0,76,74,1,0,0,0,77,80,
-		1,0,0,0,78,76,1,0,0,0,78,79,1,0,0,0,79,3,1,0,0,0,80,78,1,0,0,0,81,86,3,
-		6,3,0,82,83,5,11,0,0,83,85,3,6,3,0,84,82,1,0,0,0,85,88,1,0,0,0,86,84,1,
-		0,0,0,86,87,1,0,0,0,87,5,1,0,0,0,88,86,1,0,0,0,89,94,3,8,4,0,90,91,7,1,
-		0,0,91,93,3,8,4,0,92,90,1,0,0,0,93,96,1,0,0,0,94,92,1,0,0,0,94,95,1,0,
-		0,0,95,7,1,0,0,0,96,94,1,0,0,0,97,102,3,10,5,0,98,99,7,2,0,0,99,101,3,
-		10,5,0,100,98,1,0,0,0,101,104,1,0,0,0,102,100,1,0,0,0,102,103,1,0,0,0,
-		103,9,1,0,0,0,104,102,1,0,0,0,105,110,3,12,6,0,106,107,5,6,0,0,107,109,
-		3,12,6,0,108,106,1,0,0,0,109,112,1,0,0,0,110,108,1,0,0,0,110,111,1,0,0,
-		0,111,11,1,0,0,0,112,110,1,0,0,0,113,117,3,14,7,0,114,116,5,18,0,0,115,
-		114,1,0,0,0,116,119,1,0,0,0,117,115,1,0,0,0,117,118,1,0,0,0,118,13,1,0,
-		0,0,119,117,1,0,0,0,120,121,7,1,0,0,121,124,3,14,7,0,122,124,3,16,8,0,
-		123,120,1,0,0,0,123,122,1,0,0,0,124,15,1,0,0,0,125,133,3,30,15,0,126,127,
-		5,21,0,0,127,128,3,2,1,0,128,129,5,22,0,0,129,133,1,0,0,0,130,133,3,68,
-		34,0,131,133,3,18,9,0,132,125,1,0,0,0,132,126,1,0,0,0,132,130,1,0,0,0,
-		132,131,1,0,0,0,133,17,1,0,0,0,134,139,3,20,10,0,135,136,5,25,0,0,136,
-		138,3,20,10,0,137,135,1,0,0,0,138,141,1,0,0,0,139,137,1,0,0,0,139,140,
-		1,0,0,0,140,19,1,0,0,0,141,139,1,0,0,0,142,143,5,27,0,0,143,146,3,20,10,
-		0,144,146,3,22,11,0,145,142,1,0,0,0,145,144,1,0,0,0,146,21,1,0,0,0,147,
-		152,3,24,12,0,148,149,5,26,0,0,149,151,3,24,12,0,150,148,1,0,0,0,151,154,
-		1,0,0,0,152,150,1,0,0,0,152,153,1,0,0,0,153,23,1,0,0,0,154,152,1,0,0,0,
-		155,160,3,26,13,0,156,157,5,20,0,0,157,159,3,26,13,0,158,156,1,0,0,0,159,
-		162,1,0,0,0,160,158,1,0,0,0,160,161,1,0,0,0,161,25,1,0,0,0,162,160,1,0,
-		0,0,163,165,3,28,14,0,164,166,5,28,0,0,165,164,1,0,0,0,165,166,1,0,0,0,
-		166,27,1,0,0,0,167,177,5,1,0,0,168,169,5,21,0,0,169,170,3,18,9,0,170,171,
-		5,22,0,0,171,177,1,0,0,0,172,177,3,36,18,0,173,177,3,66,33,0,174,177,3,
-		58,29,0,175,177,3,60,30,0,176,167,1,0,0,0,176,168,1,0,0,0,176,172,1,0,
-		0,0,176,173,1,0,0,0,176,174,1,0,0,0,176,175,1,0,0,0,177,29,1,0,0,0,178,
-		187,5,2,0,0,179,187,5,3,0,0,180,187,5,4,0,0,181,187,5,5,0,0,182,183,5,
-		23,0,0,183,184,3,32,16,0,184,185,5,24,0,0,185,187,1,0,0,0,186,178,1,0,
-		0,0,186,179,1,0,0,0,186,180,1,0,0,0,186,181,1,0,0,0,186,182,1,0,0,0,187,
-		31,1,0,0,0,188,193,3,34,17,0,189,190,5,19,0,0,190,192,3,34,17,0,191,189,
-		1,0,0,0,192,195,1,0,0,0,193,191,1,0,0,0,193,194,1,0,0,0,194,33,1,0,0,0,
-		195,193,1,0,0,0,196,199,3,30,15,0,197,199,5,1,0,0,198,196,1,0,0,0,198,
-		197,1,0,0,0,199,207,1,0,0,0,200,203,5,25,0,0,201,204,3,30,15,0,202,204,
-		5,1,0,0,203,201,1,0,0,0,203,202,1,0,0,0,204,206,1,0,0,0,205,200,1,0,0,
-		0,206,209,1,0,0,0,207,205,1,0,0,0,207,208,1,0,0,0,208,35,1,0,0,0,209,207,
-		1,0,0,0,210,224,3,38,19,0,211,224,5,30,0,0,212,213,5,31,0,0,213,224,3,
-		38,19,0,214,217,5,32,0,0,215,218,3,38,19,0,216,218,5,1,0,0,217,215,1,0,
-		0,0,217,216,1,0,0,0,218,224,1,0,0,0,219,220,5,38,0,0,220,221,5,20,0,0,
-		221,222,5,32,0,0,222,224,3,38,19,0,223,210,1,0,0,0,223,211,1,0,0,0,223,
-		212,1,0,0,0,223,214,1,0,0,0,223,219,1,0,0,0,224,37,1,0,0,0,225,231,5,33,
-		0,0,226,227,5,33,0,0,227,228,5,20,0,0,228,231,5,33,0,0,229,231,5,34,0,
-		0,230,225,1,0,0,0,230,226,1,0,0,0,230,229,1,0,0,0,231,39,1,0,0,0,232,234,
-		3,42,21,0,233,232,1,0,0,0,233,234,1,0,0,0,234,241,1,0,0,0,235,237,5,25,
-		0,0,236,238,3,42,21,0,237,236,1,0,0,0,237,238,1,0,0,0,238,240,1,0,0,0,
-		239,235,1,0,0,0,240,243,1,0,0,0,241,239,1,0,0,0,241,242,1,0,0,0,242,244,
-		1,0,0,0,243,241,1,0,0,0,244,245,5,22,0,0,245,41,1,0,0,0,246,251,3,44,22,
-		0,247,248,7,0,0,0,248,250,3,44,22,0,249,247,1,0,0,0,250,253,1,0,0,0,251,
-		249,1,0,0,0,251,252,1,0,0,0,252,43,1,0,0,0,253,251,1,0,0,0,254,259,3,46,
-		23,0,255,256,5,11,0,0,256,258,3,46,23,0,257,255,1,0,0,0,258,261,1,0,0,
-		0,259,257,1,0,0,0,259,260,1,0,0,0,260,45,1,0,0,0,261,259,1,0,0,0,262,267,
-		3,48,24,0,263,264,7,1,0,0,264,266,3,48,24,0,265,263,1,0,0,0,266,269,1,
-		0,0,0,267,265,1,0,0,0,267,268,1,0,0,0,268,47,1,0,0,0,269,267,1,0,0,0,270,
-		275,3,50,25,0,271,272,7,2,0,0,272,274,3,50,25,0,273,271,1,0,0,0,274,277,
-		1,0,0,0,275,273,1,0,0,0,275,276,1,0,0,0,276,49,1,0,0,0,277,275,1,0,0,0,
-		278,283,3,52,26,0,279,280,5,6,0,0,280,282,3,52,26,0,281,279,1,0,0,0,282,
-		285,1,0,0,0,283,281,1,0,0,0,283,284,1,0,0,0,284,51,1,0,0,0,285,283,1,0,
-		0,0,286,288,3,54,27,0,287,289,5,18,0,0,288,287,1,0,0,0,288,289,1,0,0,0,
-		289,53,1,0,0,0,290,291,7,1,0,0,291,294,3,54,27,0,292,294,3,56,28,0,293,
-		290,1,0,0,0,293,292,1,0,0,0,294,55,1,0,0,0,295,303,3,30,15,0,296,297,5,
-		21,0,0,297,298,3,2,1,0,298,299,5,22,0,0,299,303,1,0,0,0,300,303,3,68,34,
-		0,301,303,3,20,10,0,302,295,1,0,0,0,302,296,1,0,0,0,302,300,1,0,0,0,302,
-		301,1,0,0,0,303,57,1,0,0,0,304,308,5,38,0,0,305,306,7,3,0,0,306,308,5,
-		38,0,0,307,304,1,0,0,0,307,305,1,0,0,0,308,59,1,0,0,0,309,311,3,62,31,
-		0,310,309,1,0,0,0,310,311,1,0,0,0,311,312,1,0,0,0,312,313,5,39,0,0,313,
-		61,1,0,0,0,314,316,5,29,0,0,315,314,1,0,0,0,315,316,1,0,0,0,316,317,1,
-		0,0,0,317,318,3,64,32,0,318,63,1,0,0,0,319,320,5,38,0,0,320,65,1,0,0,0,
-		321,322,5,35,0,0,322,323,3,40,20,0,323,67,1,0,0,0,324,330,5,36,0,0,325,
-		327,7,3,0,0,326,325,1,0,0,0,326,327,1,0,0,0,327,328,1,0,0,0,328,330,5,
-		37,0,0,329,324,1,0,0,0,329,326,1,0,0,0,330,331,1,0,0,0,331,332,3,40,20,
-		0,332,69,1,0,0,0,38,78,86,94,102,110,117,123,132,139,145,152,160,165,176,
-		186,193,198,203,207,217,223,230,233,237,241,251,259,267,275,283,288,293,
-		302,307,310,315,326,329
+		166,8,13,1,14,1,14,1,14,3,14,171,8,14,1,14,1,14,1,14,1,14,1,14,1,14,1,
+		14,1,14,3,14,181,8,14,1,15,1,15,1,15,1,15,1,15,1,15,1,15,1,15,3,15,191,
+		8,15,1,16,1,16,1,16,5,16,196,8,16,10,16,12,16,199,9,16,1,17,1,17,3,17,
+		203,8,17,1,17,1,17,1,17,3,17,208,8,17,5,17,210,8,17,10,17,12,17,213,9,
+		17,1,18,1,18,1,18,1,18,1,18,1,18,1,18,3,18,222,8,18,1,18,1,18,1,18,1,18,
+		3,18,228,8,18,1,19,1,19,1,19,1,19,1,19,3,19,235,8,19,1,20,3,20,238,8,20,
+		1,20,1,20,3,20,242,8,20,5,20,244,8,20,10,20,12,20,247,9,20,1,20,1,20,1,
+		21,1,21,1,21,5,21,254,8,21,10,21,12,21,257,9,21,1,22,1,22,1,22,5,22,262,
+		8,22,10,22,12,22,265,9,22,1,23,1,23,1,23,5,23,270,8,23,10,23,12,23,273,
+		9,23,1,24,1,24,1,24,5,24,278,8,24,10,24,12,24,281,9,24,1,25,1,25,1,25,
+		5,25,286,8,25,10,25,12,25,289,9,25,1,26,1,26,3,26,293,8,26,1,27,1,27,1,
+		27,3,27,298,8,27,1,28,1,28,1,28,1,28,1,28,1,28,1,28,3,28,307,8,28,1,29,
+		1,29,1,29,3,29,312,8,29,1,30,3,30,315,8,30,1,30,1,30,1,31,3,31,320,8,31,
+		1,31,1,31,1,32,1,32,1,33,1,33,1,33,1,34,1,34,3,34,331,8,34,1,34,3,34,334,
+		8,34,1,34,1,34,1,34,0,0,35,0,2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,
+		32,34,36,38,40,42,44,46,48,50,52,54,56,58,60,62,64,66,68,0,4,1,0,12,17,
+		1,0,9,10,1,0,7,8,2,0,29,29,32,32,357,0,70,1,0,0,0,2,73,1,0,0,0,4,81,1,
+		0,0,0,6,89,1,0,0,0,8,97,1,0,0,0,10,105,1,0,0,0,12,113,1,0,0,0,14,123,1,
+		0,0,0,16,132,1,0,0,0,18,134,1,0,0,0,20,145,1,0,0,0,22,147,1,0,0,0,24,155,
+		1,0,0,0,26,163,1,0,0,0,28,180,1,0,0,0,30,190,1,0,0,0,32,192,1,0,0,0,34,
+		202,1,0,0,0,36,227,1,0,0,0,38,234,1,0,0,0,40,237,1,0,0,0,42,250,1,0,0,
+		0,44,258,1,0,0,0,46,266,1,0,0,0,48,274,1,0,0,0,50,282,1,0,0,0,52,290,1,
+		0,0,0,54,297,1,0,0,0,56,306,1,0,0,0,58,311,1,0,0,0,60,314,1,0,0,0,62,319,
+		1,0,0,0,64,323,1,0,0,0,66,325,1,0,0,0,68,333,1,0,0,0,70,71,3,2,1,0,71,
+		72,5,0,0,1,72,1,1,0,0,0,73,78,3,4,2,0,74,75,7,0,0,0,75,77,3,4,2,0,76,74,
+		1,0,0,0,77,80,1,0,0,0,78,76,1,0,0,0,78,79,1,0,0,0,79,3,1,0,0,0,80,78,1,
+		0,0,0,81,86,3,6,3,0,82,83,5,11,0,0,83,85,3,6,3,0,84,82,1,0,0,0,85,88,1,
+		0,0,0,86,84,1,0,0,0,86,87,1,0,0,0,87,5,1,0,0,0,88,86,1,0,0,0,89,94,3,8,
+		4,0,90,91,7,1,0,0,91,93,3,8,4,0,92,90,1,0,0,0,93,96,1,0,0,0,94,92,1,0,
+		0,0,94,95,1,0,0,0,95,7,1,0,0,0,96,94,1,0,0,0,97,102,3,10,5,0,98,99,7,2,
+		0,0,99,101,3,10,5,0,100,98,1,0,0,0,101,104,1,0,0,0,102,100,1,0,0,0,102,
+		103,1,0,0,0,103,9,1,0,0,0,104,102,1,0,0,0,105,110,3,12,6,0,106,107,5,6,
+		0,0,107,109,3,12,6,0,108,106,1,0,0,0,109,112,1,0,0,0,110,108,1,0,0,0,110,
+		111,1,0,0,0,111,11,1,0,0,0,112,110,1,0,0,0,113,117,3,14,7,0,114,116,5,
+		18,0,0,115,114,1,0,0,0,116,119,1,0,0,0,117,115,1,0,0,0,117,118,1,0,0,0,
+		118,13,1,0,0,0,119,117,1,0,0,0,120,121,7,1,0,0,121,124,3,14,7,0,122,124,
+		3,16,8,0,123,120,1,0,0,0,123,122,1,0,0,0,124,15,1,0,0,0,125,133,3,30,15,
+		0,126,127,5,21,0,0,127,128,3,2,1,0,128,129,5,22,0,0,129,133,1,0,0,0,130,
+		133,3,68,34,0,131,133,3,18,9,0,132,125,1,0,0,0,132,126,1,0,0,0,132,130,
+		1,0,0,0,132,131,1,0,0,0,133,17,1,0,0,0,134,139,3,20,10,0,135,136,5,25,
+		0,0,136,138,3,20,10,0,137,135,1,0,0,0,138,141,1,0,0,0,139,137,1,0,0,0,
+		139,140,1,0,0,0,140,19,1,0,0,0,141,139,1,0,0,0,142,143,5,27,0,0,143,146,
+		3,20,10,0,144,146,3,22,11,0,145,142,1,0,0,0,145,144,1,0,0,0,146,21,1,0,
+		0,0,147,152,3,24,12,0,148,149,5,26,0,0,149,151,3,24,12,0,150,148,1,0,0,
+		0,151,154,1,0,0,0,152,150,1,0,0,0,152,153,1,0,0,0,153,23,1,0,0,0,154,152,
+		1,0,0,0,155,160,3,26,13,0,156,157,5,20,0,0,157,159,3,26,13,0,158,156,1,
+		0,0,0,159,162,1,0,0,0,160,158,1,0,0,0,160,161,1,0,0,0,161,25,1,0,0,0,162,
+		160,1,0,0,0,163,165,3,28,14,0,164,166,5,28,0,0,165,164,1,0,0,0,165,166,
+		1,0,0,0,166,27,1,0,0,0,167,170,5,1,0,0,168,171,3,38,19,0,169,171,5,1,0,
+		0,170,168,1,0,0,0,170,169,1,0,0,0,170,171,1,0,0,0,171,181,1,0,0,0,172,
+		173,5,21,0,0,173,174,3,18,9,0,174,175,5,22,0,0,175,181,1,0,0,0,176,181,
+		3,36,18,0,177,181,3,66,33,0,178,181,3,58,29,0,179,181,3,60,30,0,180,167,
+		1,0,0,0,180,172,1,0,0,0,180,176,1,0,0,0,180,177,1,0,0,0,180,178,1,0,0,
+		0,180,179,1,0,0,0,181,29,1,0,0,0,182,191,5,2,0,0,183,191,5,3,0,0,184,191,
+		5,4,0,0,185,191,5,5,0,0,186,187,5,23,0,0,187,188,3,32,16,0,188,189,5,24,
+		0,0,189,191,1,0,0,0,190,182,1,0,0,0,190,183,1,0,0,0,190,184,1,0,0,0,190,
+		185,1,0,0,0,190,186,1,0,0,0,191,31,1,0,0,0,192,197,3,34,17,0,193,194,5,
+		19,0,0,194,196,3,34,17,0,195,193,1,0,0,0,196,199,1,0,0,0,197,195,1,0,0,
+		0,197,198,1,0,0,0,198,33,1,0,0,0,199,197,1,0,0,0,200,203,3,30,15,0,201,
+		203,5,1,0,0,202,200,1,0,0,0,202,201,1,0,0,0,203,211,1,0,0,0,204,207,5,
+		25,0,0,205,208,3,30,15,0,206,208,5,1,0,0,207,205,1,0,0,0,207,206,1,0,0,
+		0,208,210,1,0,0,0,209,204,1,0,0,0,210,213,1,0,0,0,211,209,1,0,0,0,211,
+		212,1,0,0,0,212,35,1,0,0,0,213,211,1,0,0,0,214,228,3,38,19,0,215,228,5,
+		30,0,0,216,217,5,31,0,0,217,228,3,38,19,0,218,221,5,32,0,0,219,222,3,38,
+		19,0,220,222,5,1,0,0,221,219,1,0,0,0,221,220,1,0,0,0,222,228,1,0,0,0,223,
+		224,5,38,0,0,224,225,5,20,0,0,225,226,5,32,0,0,226,228,3,38,19,0,227,214,
+		1,0,0,0,227,215,1,0,0,0,227,216,1,0,0,0,227,218,1,0,0,0,227,223,1,0,0,
+		0,228,37,1,0,0,0,229,235,5,33,0,0,230,231,5,33,0,0,231,232,5,20,0,0,232,
+		235,5,33,0,0,233,235,5,34,0,0,234,229,1,0,0,0,234,230,1,0,0,0,234,233,
+		1,0,0,0,235,39,1,0,0,0,236,238,3,42,21,0,237,236,1,0,0,0,237,238,1,0,0,
+		0,238,245,1,0,0,0,239,241,5,25,0,0,240,242,3,42,21,0,241,240,1,0,0,0,241,
+		242,1,0,0,0,242,244,1,0,0,0,243,239,1,0,0,0,244,247,1,0,0,0,245,243,1,
+		0,0,0,245,246,1,0,0,0,246,248,1,0,0,0,247,245,1,0,0,0,248,249,5,22,0,0,
+		249,41,1,0,0,0,250,255,3,44,22,0,251,252,7,0,0,0,252,254,3,44,22,0,253,
+		251,1,0,0,0,254,257,1,0,0,0,255,253,1,0,0,0,255,256,1,0,0,0,256,43,1,0,
+		0,0,257,255,1,0,0,0,258,263,3,46,23,0,259,260,5,11,0,0,260,262,3,46,23,
+		0,261,259,1,0,0,0,262,265,1,0,0,0,263,261,1,0,0,0,263,264,1,0,0,0,264,
+		45,1,0,0,0,265,263,1,0,0,0,266,271,3,48,24,0,267,268,7,1,0,0,268,270,3,
+		48,24,0,269,267,1,0,0,0,270,273,1,0,0,0,271,269,1,0,0,0,271,272,1,0,0,
+		0,272,47,1,0,0,0,273,271,1,0,0,0,274,279,3,50,25,0,275,276,7,2,0,0,276,
+		278,3,50,25,0,277,275,1,0,0,0,278,281,1,0,0,0,279,277,1,0,0,0,279,280,
+		1,0,0,0,280,49,1,0,0,0,281,279,1,0,0,0,282,287,3,52,26,0,283,284,5,6,0,
+		0,284,286,3,52,26,0,285,283,1,0,0,0,286,289,1,0,0,0,287,285,1,0,0,0,287,
+		288,1,0,0,0,288,51,1,0,0,0,289,287,1,0,0,0,290,292,3,54,27,0,291,293,5,
+		18,0,0,292,291,1,0,0,0,292,293,1,0,0,0,293,53,1,0,0,0,294,295,7,1,0,0,
+		295,298,3,54,27,0,296,298,3,56,28,0,297,294,1,0,0,0,297,296,1,0,0,0,298,
+		55,1,0,0,0,299,307,3,30,15,0,300,301,5,21,0,0,301,302,3,2,1,0,302,303,
+		5,22,0,0,303,307,1,0,0,0,304,307,3,68,34,0,305,307,3,20,10,0,306,299,1,
+		0,0,0,306,300,1,0,0,0,306,304,1,0,0,0,306,305,1,0,0,0,307,57,1,0,0,0,308,
+		312,5,38,0,0,309,310,7,3,0,0,310,312,5,38,0,0,311,308,1,0,0,0,311,309,
+		1,0,0,0,312,59,1,0,0,0,313,315,3,62,31,0,314,313,1,0,0,0,314,315,1,0,0,
+		0,315,316,1,0,0,0,316,317,5,39,0,0,317,61,1,0,0,0,318,320,5,29,0,0,319,
+		318,1,0,0,0,319,320,1,0,0,0,320,321,1,0,0,0,321,322,3,64,32,0,322,63,1,
+		0,0,0,323,324,5,38,0,0,324,65,1,0,0,0,325,326,5,35,0,0,326,327,3,40,20,
+		0,327,67,1,0,0,0,328,334,5,36,0,0,329,331,7,3,0,0,330,329,1,0,0,0,330,
+		331,1,0,0,0,331,332,1,0,0,0,332,334,5,37,0,0,333,328,1,0,0,0,333,330,1,
+		0,0,0,334,335,1,0,0,0,335,336,3,40,20,0,336,69,1,0,0,0,39,78,86,94,102,
+		110,117,123,132,139,145,152,160,165,170,180,190,197,202,207,211,221,227,
+		234,237,241,245,255,263,271,279,287,292,297,306,311,314,319,330,333
 	};
 
 	public static readonly ATN _ATN =

--- a/src/ClosedXML.ANTLR/FormulaParser.g4
+++ b/src/ClosedXML.ANTLR/FormulaParser.g4
@@ -87,10 +87,12 @@ ref_spill_expression
 
 /*
  * name_reference and structure_reference are not very unambiguous, e.g.
- * BOOK_PREFIX NAME are a prefix for both
+ * BOOK_PREFIX NAME are a prefix for both.
+ * Although #REF!A1 and such is not a valid according to grammar, it is a
+ * result of sheet deletion in actual formulas.
  */
 ref_atom_expression
-        : REF_CONSTANT
+        : REF_CONSTANT (a1_reference | REF_CONSTANT)?
         | OPEN_BRACE ref_expression CLOSE_BRACE
         | cell_reference
         | ref_function_call

--- a/src/ClosedXML.Parser.Tests/FormulaConverterToR1C1Tests.cs
+++ b/src/ClosedXML.Parser.Tests/FormulaConverterToR1C1Tests.cs
@@ -29,6 +29,15 @@ public class FormulaConverterToR1C1Tests
     }
 
     [Theory]
+    [InlineData("SUM(#REF!$B$7)", "SUM(#REF!R7C2)")]
+    [InlineData("SUM(Sheet!#REF!)", "SUM(Sheet!#REF!)")]
+    [InlineData("SUM(#REF!#REF!)", "SUM(#REF!#REF!)")]
+    public void ErrorNode(string a1, string r1c1)
+    {
+        Assert.Equal(r1c1, FormulaConverter.ToR1C1(a1, 1, 1));
+    }
+
+    [Theory]
     [InlineData("B4", 4, 2, "RC")] // A1 Relative
     [InlineData("B4", 5, 2, "R[-1]C")]
     [InlineData("B4", 4, 1, "RC[1]")]

--- a/src/ClosedXML.Parser.Tests/Rules/RefAtomExpressionRuleTests.cs
+++ b/src/ClosedXML.Parser.Tests/Rules/RefAtomExpressionRuleTests.cs
@@ -8,6 +8,22 @@ public class RefAtomExpressionRuleTests
         VerifyNode("#REF!", new ValueNode("Error", "#REF!"));
     }
 
+    [Theory]
+    [InlineData("#REF!A1")]
+    [InlineData("#REF!$B$7")]
+    [InlineData("#REF!A1:B5")]
+    [InlineData("#REF!$D7:G$15")]
+    [InlineData("#REF!7:15")]
+    [InlineData("#REF!$7:$15")]
+    [InlineData("#REF!B:AG")]
+    [InlineData("#REF!$ABC:$ADD")]
+    [InlineData("Sheet!#REF!")]
+    [InlineData("#REF!#REF!")]
+    public void Ref_error_with_reference(string refError)
+    {
+        VerifyNode(refError, new ValueNode("Error", "#REF!"));
+    }
+
     [Fact]
     public void Nested_ref_expression()
     {

--- a/src/ClosedXML.Parser/FormulaConverter.cs
+++ b/src/ClosedXML.Parser/FormulaConverter.cs
@@ -22,7 +22,7 @@ public static class FormulaConverter
     /// <exception cref="ParsingException">The formula is not parseable.</exception>
     public static string ToR1C1(string formulaA1, int row, int col)
     {
-        var ctx = new TransformContext(formulaA1, row, col);
+        var ctx = new TransformContext(formulaA1, row, col, isA1: true);
         var transformedFormula = FormulaParser<TransformedSymbol, TransformedSymbol, TransformContext>.CellFormulaA1(formulaA1, ctx, s_visitorR1C1);
         return Normalize(transformedFormula, formulaA1);
     }
@@ -37,7 +37,7 @@ public static class FormulaConverter
     /// <exception cref="ParsingException">The formula is not parseable.</exception>
     public static string ToA1(string formulaR1C1, int row, int col)
     {
-        var ctx = new TransformContext(formulaR1C1, row, col);
+        var ctx = new TransformContext(formulaR1C1, row, col, isA1: false);
         var transformedFormula = FormulaParser<TransformedSymbol, TransformedSymbol, TransformContext>.CellFormulaR1C1(formulaR1C1, ctx, s_visitorA1);
         return Normalize(transformedFormula, formulaR1C1);
     }

--- a/src/ClosedXML.Parser/IAstFactory.cs
+++ b/src/ClosedXML.Parser/IAstFactory.cs
@@ -48,7 +48,7 @@ public interface IAstFactory<TScalarValue, TNode, in TContext>
     /// </summary>
     /// <param name="context">User supplied context for parsing a tree that is an argument of a parsing method.</param>
     /// <param name="range">Symbol range of the error token in the formula.</param>
-    /// <param name="error">The error text, string with <c>#</c> until the end of an error. No whitespace, converted to upper case, no matter the input..</param>
+    /// <param name="error">The error text, string with <c>#</c> until the end of an error. No whitespace, converted to upper case, no matter the input.</param>
     TScalarValue ErrorValue(TContext context, SymbolRange range, ReadOnlySpan<char> error);
 
     /// <summary>
@@ -79,6 +79,11 @@ public interface IAstFactory<TScalarValue, TNode, in TContext>
     /// <summary>
     /// Create a node with an error value.
     /// </summary>
+    /// <remarks>
+    /// Sheet related ref errors (e.g. <c>Sheet!REF!</c> or <c>#REF!$A$4</c>) are also use this node. In that case,
+    /// the <paramref name="range"/> contains whole section used to create the error, but <paramref name="error"/>
+    /// contains normalized <c>#REF!</c> error.
+    /// </remarks>
     /// <param name="context">User supplied context for parsing a tree that is an argument of a parsing method.</param>
     /// <param name="range">Range in a formula that contains the error.</param>
     /// <param name="error">The error text, string with <c>#</c> until the end of an error. No whitespace. In upper case format.</param>

--- a/src/ClosedXML.Parser/SymbolRange.cs
+++ b/src/ClosedXML.Parser/SymbolRange.cs
@@ -26,6 +26,11 @@ public readonly struct SymbolRange
     public int End { get; }
 
     /// <summary>
+    /// Length of a symbol.
+    /// </summary>
+    public int Length => End - Start;
+
+    /// <summary>
     /// Get range indexes.
     /// </summary>
     public override string ToString()

--- a/src/ClosedXML.Parser/TransformContext.cs
+++ b/src/ClosedXML.Parser/TransformContext.cs
@@ -4,7 +4,7 @@ namespace ClosedXML.Parser;
 
 internal sealed class TransformContext
 {
-    internal TransformContext(string formula, int row, int col)
+    internal TransformContext(string formula, int row, int col, bool isA1)
     {
         if (row is < 1 or > RowCol.MaxRow)
             throw new ArgumentOutOfRangeException(nameof(row));
@@ -15,6 +15,7 @@ internal sealed class TransformContext
         Formula = formula;
         Row = row;
         Col = col;
+        IsA1 = isA1;
     }
 
     internal string Formula { get; }
@@ -28,4 +29,9 @@ internal sealed class TransformContext
     /// Absolute column number in a sheet.
     /// </summary>
     internal int Col { get; }
+
+    /// <summary>
+    /// Should references in formula be A1?
+    /// </summary>
+    internal bool IsA1 { get; }
 }


### PR DESCRIPTION
Reference can have its sheet part or A1 reference deleted, e.g. (Sheet!A1 -> #REF!A1 or Sheet!#REF! or #REF!#REF!). The Sheet!#REF! is valid per grammar, rest is not.