### PR TITLE
Fix incorrect parsing and serialization of row span (7:10) and col span (D:E).

### DIFF
--- a/src/ClosedXML.Parser.Tests/Lexers/A1SpanReferenceTokenTests.cs
+++ b/src/ClosedXML.Parser.Tests/Lexers/A1SpanReferenceTokenTests.cs
@@ -1,4 +1,6 @@
-﻿namespace ClosedXML.Parser.Tests.Lexers;
+﻿using static ClosedXML.Parser.ReferenceAxisType;
+
+namespace ClosedXML.Parser.Tests.Lexers;
 
 /// <summary>
 /// Test of a parsing of a token <c>A1_SPAN_REFERENCE</c>.
@@ -15,23 +17,23 @@ public class A1SpanReferenceTokenTests
     public void Parse_row_range()
     {
         // Check A1_ROW ':' A1_ROW path
-        AssertAreaReferenceToken("1:1", new ReferenceArea(new RowCol(false, 1, true, 1, A1), new RowCol(false, 1, true, RowCol.MaxCol, A1)));
-        AssertAreaReferenceToken("$5:10", new ReferenceArea(new RowCol(true, 5, true, 1, A1), new RowCol(false, 10, true, RowCol.MaxCol, A1)));
-        AssertAreaReferenceToken("7:$3", new ReferenceArea(new RowCol(false, 7, true, 1, A1), new RowCol(true, 3, true, RowCol.MaxCol, A1)));
-        AssertAreaReferenceToken("$1048576:$1048576", new ReferenceArea(new RowCol(true, RowCol.MaxRow, true, 1, A1), new RowCol(true, RowCol.MaxRow, true, RowCol.MaxCol, A1)));
+        AssertAreaReferenceToken("1:1", new ReferenceArea(new RowCol(Relative, 1, None, 0, A1), new RowCol(Relative, 1, None, 0, A1)));
+        AssertAreaReferenceToken("$5:10", new ReferenceArea(new RowCol(Absolute, 5, None, 0, A1), new RowCol(Relative, 10, None, 0, A1)));
+        AssertAreaReferenceToken("7:$3", new ReferenceArea(new RowCol(Relative, 7, None, 0, A1), new RowCol(Absolute, 3, None, 0, A1)));
+        AssertAreaReferenceToken("$1048576:$1048576", new ReferenceArea(new RowCol(Absolute, RowCol.MaxRow, None, 0, A1), new RowCol(Absolute, RowCol.MaxRow, None, 0, A1)));
     }
 
     [Fact]
     public void Parse_column_range()
     {
         // Check A1_COLUMN ':' A1_COLUMN path
-        AssertAreaReferenceToken("A:A", new ReferenceArea(new RowCol(true, 1, false, 1, A1), new RowCol(true, RowCol.MaxRow, false, 1, A1)));
-        AssertAreaReferenceToken("RW:ST", new ReferenceArea(new RowCol(true, 1, false, 491, A1), new RowCol(true, RowCol.MaxRow, false, 514, A1)));
-        AssertAreaReferenceToken("$C:D", new ReferenceArea(new RowCol(true, 1, true, 3, A1), new RowCol(true, RowCol.MaxRow, false, 4, A1)));
-        AssertAreaReferenceToken("E:$C", new ReferenceArea(new RowCol(true, 1, false, 5, A1), new RowCol(true, RowCol.MaxRow, true, 3, A1)));
-        AssertAreaReferenceToken("$XFD:$XFD", new ReferenceArea(new RowCol(true, 1, true, RowCol.MaxCol, A1), new RowCol(true, RowCol.MaxRow, true, RowCol.MaxCol, A1)));
+        AssertAreaReferenceToken("A:A", new ReferenceArea(new RowCol(None, 0, Relative, 1, A1), new RowCol(None, 0, Relative, 1, A1)));
+        AssertAreaReferenceToken("RW:ST", new ReferenceArea(new RowCol(None, 0, Relative, 491, A1), new RowCol(None, 0, Relative, 514, A1)));
+        AssertAreaReferenceToken("$C:D", new ReferenceArea(new RowCol(None, 0, Absolute, 3, A1), new RowCol(None, 0, Relative, 4, A1)));
+        AssertAreaReferenceToken("E:$C", new ReferenceArea(new RowCol(None, 0, Relative, 5, A1), new RowCol(None, 0, Absolute, 3, A1)));
+        AssertAreaReferenceToken("$XFD:$XFD", new ReferenceArea(new RowCol(None, 0, Absolute, RowCol.MaxCol, A1), new RowCol(None, 0, Absolute, RowCol.MaxCol, A1)));
     }
-    
+
     private static void AssertAreaReferenceToken(string token, ReferenceArea expectedReference)
     {
         AssertFormula.AssertTokenType(token, FormulaLexer.A1_SPAN_REFERENCE);

--- a/src/ClosedXML.Parser.Tests/ReferenceAreaTests.cs
+++ b/src/ClosedXML.Parser.Tests/ReferenceAreaTests.cs
@@ -1,4 +1,6 @@
-﻿namespace ClosedXML.Parser.Tests;
+﻿using static ClosedXML.Parser.ReferenceAxisType;
+
+namespace ClosedXML.Parser.Tests;
 
 public class ReferenceAreaTests
 {
@@ -7,6 +9,7 @@ public class ReferenceAreaTests
     public void DisplayStringA1_displays_reference_in_A1_style(ReferenceArea reference, string expectedString)
     {
         Assert.Equal(expectedString, reference.GetDisplayStringA1());
+        Assert.Equal(reference, TokenParser.ParseReference(expectedString, true));
     }
 
     [Theory]
@@ -14,6 +17,7 @@ public class ReferenceAreaTests
     public void DisplayStringR1C1_displays_reference_in_R1C1_style(ReferenceArea reference, string expectedString)
     {
         Assert.Equal(expectedString, reference.GetDisplayStringR1C1());
+        Assert.Equal(reference, TokenParser.ParseReference(expectedString, false));
     }
 
     public static IEnumerable<object[]> DisplayStringA1
@@ -23,15 +27,77 @@ public class ReferenceAreaTests
             // When both corners are same, only one is rendered.
             yield return new object[]
             {
-                new ReferenceArea(new RowCol(ReferenceAxisType.Relative, 1, ReferenceAxisType.Relative, 1, A1), new RowCol(ReferenceAxisType.Relative, 1, ReferenceAxisType.Relative, 1, A1)),
+                new ReferenceArea(new RowCol(Relative, 1, Relative, 1, A1), new RowCol(Relative, 1, Relative, 1, A1)),
                 "A1"
             };
 
             // When both corners are same, only one is rendered.
             yield return new object[]
             {
-                new ReferenceArea(new RowCol(ReferenceAxisType.Relative, 1, ReferenceAxisType.Relative, 1, A1), new RowCol(ReferenceAxisType.Relative, 5, ReferenceAxisType.Relative, 3, A1)),
+                new ReferenceArea(new RowCol(Relative, 1, Relative, 1, A1), new RowCol(Relative, 5, Relative, 3, A1)),
                 "A1:C5"
+            };
+
+            // Row span
+            yield return new object[]
+            {
+                new ReferenceArea(new RowCol(Relative, 6, None, 0, A1), new RowCol(Relative, 6, None, 0, A1)),
+                "6:6"
+            };
+
+            yield return new object[]
+            {
+                new ReferenceArea(new RowCol(Relative, 6, None, 0, A1), new RowCol(Relative, 8, None, 0, A1)),
+                "6:8"
+            };
+
+            yield return new object[]
+            {
+                new ReferenceArea(new RowCol(Absolute, 65, None, 0, A1), new RowCol(Absolute, 745, None, 0, A1)),
+                "$65:$745"
+            };
+
+            yield return new object[]
+            {
+                new ReferenceArea(new RowCol(Relative, 79, None, 0, A1), new RowCol(Absolute, 999, None, 0, A1)),
+                "79:$999"
+            };
+
+            yield return new object[]
+            {
+                new ReferenceArea(new RowCol(Absolute, 79, None, 0, A1), new RowCol(Relative, 999, None, 0, A1)),
+                "$79:999"
+            };
+
+            // Col span
+            yield return new object[]
+            {
+                new ReferenceArea(new RowCol(None, 0, Relative, 5, A1), new RowCol(None, 0, Relative, 5, A1)),
+                "E:E"
+            };
+
+            yield return new object[]
+            {
+                new ReferenceArea(new RowCol(None, 0, Relative, 2, A1), new RowCol(None, 0, Relative, 4, A1)),
+                "B:D"
+            };
+
+            yield return new object[]
+            {
+                new ReferenceArea(new RowCol(None, 0, Absolute, 27, A1), new RowCol(None, 0, Absolute, 53, A1)),
+                "$AA:$BA"
+            };
+
+            yield return new object[]
+            {
+                new ReferenceArea(new RowCol(None, 0, Relative, 96, A1), new RowCol(None, 0, Absolute, 6663, A1)),
+                "CR:$IVG"
+            };
+
+            yield return new object[]
+            {
+                new ReferenceArea(new RowCol(None, 0, Absolute, 96, A1), new RowCol(None, 0, Relative, 6663, A1)),
+                "$CR:IVG"
             };
         }
     }
@@ -42,15 +108,77 @@ public class ReferenceAreaTests
         {
             yield return new object[]
             {
-                new ReferenceArea(new RowCol(ReferenceAxisType.Absolute, 7, ReferenceAxisType.Absolute, 1, R1C1), new RowCol(ReferenceAxisType.Absolute, 7, ReferenceAxisType.Absolute, 1, R1C1)),
+                new ReferenceArea(new RowCol(Absolute, 7, Absolute, 1, R1C1), new RowCol(Absolute, 7, Absolute, 1, R1C1)),
                 "R7C1"
             };
 
             yield return new object[]
             {
-                new ReferenceArea(new RowCol(ReferenceAxisType.Absolute, 7, ReferenceAxisType.Absolute, 1, R1C1), new RowCol(ReferenceAxisType.Relative, 0, ReferenceAxisType.None, 0, R1C1)),
+                new ReferenceArea(new RowCol(Absolute, 7, Absolute, 1, R1C1), new RowCol(Relative, 0, None, 0, R1C1)),
                 "R7C1:R"
             };
-       }
+
+            // Row span
+            yield return new object[]
+            {
+                new ReferenceArea(new RowCol(Relative, 6, None, 0, R1C1), new RowCol(Relative, 6, None, 0, R1C1)),
+                "R[6]"
+            };
+
+            yield return new object[]
+            {
+                new ReferenceArea(new RowCol(Relative, 6, None, 0, R1C1), new RowCol(Relative, 8, None, 0, R1C1)),
+                "R[6]:R[8]"
+            };
+
+            yield return new object[]
+            {
+                new ReferenceArea(new RowCol(Absolute, 65, None, 0, R1C1), new RowCol(Absolute, 745, None, 0, R1C1)),
+                "R65:R745"
+            };
+
+            yield return new object[]
+            {
+                new ReferenceArea(new RowCol(Relative, 79, None, 0, R1C1), new RowCol(Absolute, 999, None, 0, R1C1)),
+                "R[79]:R999"
+            };
+
+            yield return new object[]
+            {
+                new ReferenceArea(new RowCol(Absolute, 79, None, 0, R1C1), new RowCol(Relative, 999, None, 0, R1C1)),
+                "R79:R[999]"
+            };
+
+            // Col span
+            yield return new object[]
+            {
+                new ReferenceArea(new RowCol(None, 0, Relative, 2, R1C1), new RowCol(None, 0, Relative, 2, R1C1)),
+                "C[2]"
+            };
+
+            yield return new object[]
+            {
+                new ReferenceArea(new RowCol(None, 0, Relative, 2, R1C1), new RowCol(None, 0, Relative, 4, R1C1)),
+                "C[2]:C[4]"
+            };
+
+            yield return new object[]
+            {
+                new ReferenceArea(new RowCol(None, 0, Absolute, 27, R1C1), new RowCol(None, 0, Absolute, 53, R1C1)),
+                "C27:C53"
+            };
+
+            yield return new object[]
+            {
+                new ReferenceArea(new RowCol(None, 0, Relative, 96, R1C1), new RowCol(None, 0, Absolute, 663, R1C1)),
+                "C[96]:C663"
+            };
+
+            yield return new object[]
+            {
+                new ReferenceArea(new RowCol(None, 0, Absolute, 96, R1C1), new RowCol(None, 0, Relative, 663, R1C1)),
+                "C96:C[663]"
+            };
+        }
     }
 }

--- a/src/ClosedXML.Parser/ReferenceArea.cs
+++ b/src/ClosedXML.Parser/ReferenceArea.cs
@@ -82,7 +82,7 @@ public readonly struct ReferenceArea
     /// </summary>
     public string GetDisplayStringA1()
     {
-        if (First == Second)
+        if (First == Second && !First.IsColumn && !First.IsRow)
             return First.GetDisplayStringA1();
 
         return new StringBuilder()

--- a/src/ClosedXML.Parser/RowCol.cs
+++ b/src/ClosedXML.Parser/RowCol.cs
@@ -74,6 +74,16 @@ public readonly struct RowCol : IEquatable<RowCol>
     public ReferenceStyle Style { get; }
 
     /// <summary>
+    /// Is RowCol a part (start or end) of row span?
+    /// </summary>
+    public bool IsRow => ColumnType == None;
+
+    /// <summary>
+    /// Is RowCol a part (start or end) of column span?
+    /// </summary>
+    public bool IsColumn => RowType == None;
+
+    /// <summary>
     /// Create a new <see cref="RowCol"/> with both row and columns specified.
     /// </summary>
     /// <param name="rowType">The type used to interpret the row position.</param>

--- a/src/ClosedXML.Parser/TokenParser.cs
+++ b/src/ClosedXML.Parser/TokenParser.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using static ClosedXML.Parser.ReferenceAxisType;
 
 namespace ClosedXML.Parser;
 
@@ -252,8 +253,8 @@ internal static class TokenParser
 
             var row2 = ReadRow(input, ref i);
             return new ReferenceArea(
-                new RowCol(abs1, row1, true, 1, A1),
-                new RowCol(absRow2, row2, true, RowCol.MaxCol, A1));
+                new RowCol(abs1 ? Absolute : Relative, row1, None, 0, A1),
+                new RowCol(absRow2 ? Absolute : Relative, row2, None, 0, A1));
         }
 
         var col = ReadColumn(input, ref i);
@@ -267,8 +268,8 @@ internal static class TokenParser
 
             var col2 = ReadColumn(input, ref i);
             return new ReferenceArea(
-                new RowCol(true, 1, abs1, col, A1),
-                new RowCol(true, RowCol.MaxRow, absCol2, col2, A1));
+                new RowCol(None, 0, abs1 ? Absolute : Relative, col, A1),
+                new RowCol(None, 0, absCol2 ? Absolute : Relative, col2, A1));
         }
 
         var secondAbsolute = IsAbsolute(input, i);

--- a/src/ClosedXML.Parser/TokenParser.cs
+++ b/src/ClosedXML.Parser/TokenParser.cs
@@ -160,7 +160,7 @@ internal static class TokenParser
         {
             // Token is COLUMN. ROW must be after column, so there can't be one.
             var loneCol = ReadR1C1Axis(token, ref i);
-            return new RowCol(ReferenceAxisType.None, 0, loneCol.Type, loneCol.Value, R1C1);
+            return new RowCol(None, 0, loneCol.Type, loneCol.Value, R1C1);
         }
 
         // It must be a row.
@@ -171,7 +171,7 @@ internal static class TokenParser
 
         // Token is ROW. Either it has ended or it is followed by :
         if (i == token.Length || token[i] is not ('C' or 'c'))
-            return new RowCol(row.Type, row.Value, ReferenceAxisType.None, 0, R1C1);
+            return new RowCol(row.Type, row.Value, None, 0, R1C1);
 
         // Token is ROW COLUMN
         var col = ReadR1C1Axis(token, ref i);
@@ -191,7 +191,7 @@ internal static class TokenParser
         {
             // We are at the end of a formula and the only thing that was left was C/R, an alias for C[0]/R[0]
             currentIdx = i;
-            return (ReferenceAxisType.Relative, 0);
+            return (Relative, 0);
         }
 
         if (token[i] == '[')
@@ -212,7 +212,7 @@ internal static class TokenParser
 
             // Index is at the last character that has to be ']'
             currentIdx = ++i;
-            return (ReferenceAxisType.Relative, isNegative ? -position : position);
+            return (Relative, isNegative ? -position : position);
         }
 
         // Axis is absolute or relative [0] without explicit number.
@@ -224,9 +224,9 @@ internal static class TokenParser
 
         // There is no number after 'C'/'R' => it's a shorthand for `C[0]`/`R[0]`
         if (absoluteNumber == 0)
-            return (ReferenceAxisType.Relative, 0);
+            return (Relative, 0);
 
-        return (ReferenceAxisType.Absolute, absoluteNumber);
+        return (Absolute, absoluteNumber);
     }
 
     /// <summary>


### PR DESCRIPTION
Token parser had a bug, where row/col spans were incorrectly parsed as an area, e.g. A:D had been parsed as A$1:D$1048576. That is not correct, reference must be able to represent any A1/R1C1 reference accurately and these two representations are not same. 

there was also a bug converting row/col spans to A1, e.g. `A:A` had been rendered as only `A`, which is not correct. Dtto rows.