### PR TITLE
Add ability to delete sheet during formula conversion instead of just renaming.

### DIFF
--- a/src/ClosedXML.Parser.Tests/FormulaGeneratorVisitorTests.cs
+++ b/src/ClosedXML.Parser.Tests/FormulaGeneratorVisitorTests.cs
@@ -12,6 +12,78 @@ public class FormulaGeneratorVisitorTests
         AssertChangesA1(formula, factory, modifiedFormula);
     }
 
+    [Theory]
+    [InlineData("Old!#REF!", "Old", null, "#REF!#REF!")]
+    [InlineData("Old!#REF!", "Old", "New", "New!#REF!")]
+    public void ErrorNode_can_modify_sheet(string formula, string oldSheetName, string? newSheetName, string modifiedFormula)
+    {
+        var factory = new FormulaFactory { SheetMap = { { oldSheetName, newSheetName } } };
+        AssertChangesA1(formula, factory, modifiedFormula);
+    }
+
+    [Theory]
+    [InlineData("Old!B$5", "Old", null, "#REF!B$5")]
+    [InlineData("Old!B:D", "Old", "Shiny", "Shiny!B:D")]
+    public void SheetReference_can_modify_sheet(string formula, string oldSheetName, string? newSheetName, string modifiedFormula)
+    {
+        var factory = new FormulaFactory { SheetMap = { { oldSheetName, newSheetName } } };
+        AssertChangesA1(formula, factory, modifiedFormula);
+    }
+
+    [Theory]
+    [InlineData("Old!F(5)", "Old", null, "#REF!")]
+    [InlineData("Old!F(7)", "Old", "Shiny", "Shiny!F(7)")]
+    public void SheetFunction_can_modify_sheet(string formula, string oldSheetName, string? newSheetName, string modifiedFormula)
+    {
+        var factory = new FormulaFactory { SheetMap = { { oldSheetName, newSheetName } } };
+        AssertChangesA1(formula, factory, modifiedFormula);
+    }
+
+    [Theory]
+    [InlineData("Sheet1:Sheet5!A1", "Sheet1", null, "#REF!")]
+    [InlineData("Sheet1:Sheet5!A1", "Sheet1", "New sheet", "'New sheet:Sheet5'!A1")]
+    [InlineData("Sheet1:Sheet5!A1", "Sheet5", "Sheet9", "Sheet1:Sheet9!A1")]
+    public void Reference3D_can_modify_sheet(string formula, string oldSheetName, string? newSheetName, string modifiedFormula)
+    {
+        var factory = new FormulaFactory { SheetMap = { { oldSheetName, newSheetName } } };
+        AssertChangesA1(formula, factory, modifiedFormula);
+    }
+
+    [Theory]
+    [InlineData("[1]Sheet!A1", "Sheet", null, "#REF!")]
+    [InlineData("[1]Sheet!A1", "Sheet", "New Sheet", "'[1]New Sheet'!A1")]
+    public void ExternalSheetReference_can_modify_sheet(string formula, string oldSheetName, string? newSheetName, string modifiedFormula)
+    {
+        var factory = new FormulaFactory { ExternalSheetMap = { { oldSheetName, newSheetName } } };
+        AssertChangesA1(formula, factory, modifiedFormula);
+    }
+
+    [Theory]
+    [InlineData("[1]Sheet!F(5)", "Sheet", null, "#REF!")]
+    [InlineData("[1]Sheet!Func(7, TRUE)", "Sheet", "New Sheet", "'[1]New Sheet'!Func(7, TRUE)")]
+    public void ExternalFunction_can_modify_sheet(string formula, string oldSheetName, string? newSheetName, string modifiedFormula)
+    {
+        var factory = new FormulaFactory { ExternalSheetMap = { { oldSheetName, newSheetName } } };
+        AssertChangesA1(formula, factory, modifiedFormula);
+    }
+
+    [Theory]
+    [InlineData("Sheet!Name", "Sheet", null, "#REF!")]
+    [InlineData("Sheet!Name", "Sheet", "New Sheet", "'New Sheet'!Name")]
+    public void SheetName_can_modify_sheet(string formula, string oldSheetName, string? newSheetName, string modifiedFormula)
+    {
+        var factory = new FormulaFactory { SheetMap = { { oldSheetName, newSheetName } } };
+        AssertChangesA1(formula, factory, modifiedFormula);
+    }
+
+    [Theory]
+    [InlineData("[1]Sheet!Name", "Sheet", null, "#REF!")]
+    [InlineData("[66]Sheet!Name", "Sheet", "New Sheet", "'[66]New Sheet'!Name")]
+    public void ExternalSheetName_can_modify_sheet(string formula, string oldSheetName, string? newSheetName, string modifiedFormula)
+    {
+        var factory = new FormulaFactory { ExternalSheetMap = { { oldSheetName, newSheetName } } };
+        AssertChangesA1(formula, factory, modifiedFormula);
+    }
     private static void AssertChangesA1(string formula, FormulaGeneratorVisitor factory, string expected)
     {
         var ctx = new TransformContext(formula, 1, 1, isA1: true);
@@ -21,14 +93,24 @@ public class FormulaGeneratorVisitorTests
 
     private class FormulaFactory : FormulaGeneratorVisitor
     {
-        public Dictionary<string, string> SheetMap { get; } = new();
+        public Dictionary<string, string?> SheetMap { get; } = new();
+        public Dictionary<string, string?> ExternalSheetMap { get; } = new();
 
-        protected override string ModifySheet(TransformContext ctx, string sheetName)
+        protected override string? ModifySheet(TransformContext ctx, string sheetName)
         {
             if (SheetMap.TryGetValue(sheetName, out var replacement))
                 return replacement;
 
             return sheetName;
         }
+
+        protected override string? ModifyExternalSheet(TransformContext ctx, int bookIndex, string sheetName)
+        {
+            if (ExternalSheetMap.TryGetValue(sheetName, out var replacement))
+                return replacement;
+
+            return sheetName;
+        }
+
     }
 }

--- a/src/ClosedXML.Parser.Tests/FormulaGeneratorVisitorTests.cs
+++ b/src/ClosedXML.Parser.Tests/FormulaGeneratorVisitorTests.cs
@@ -1,0 +1,34 @@
+﻿namespace ClosedXML.Parser.Tests;
+
+public class FormulaGeneratorVisitorTests
+{
+    [Theory]
+    [InlineData("Old!B7:$D$10", "Old", "New", "New!B7:$D$10")]
+    [InlineData("Old!B7:$D$10", "Old", "New sheet", "'New sheet'!B7:$D$10")]
+    [InlineData("'Old Mike''s sheet'!B7:$D$10", "Old Mike's sheet", "New Mike's sheet", "'New Mike''s sheet'!B7:$D$10")]
+    public void ModifySheet_can_rename_sheet_name(string formula, string oldSheetName, string newSheetName, string modifiedFormula)
+    {
+        var factory = new FormulaFactory { SheetMap = { { oldSheetName, newSheetName } } };
+        AssertChangesA1(formula, factory, modifiedFormula);
+    }
+
+    private static void AssertChangesA1(string formula, FormulaGeneratorVisitor factory, string expected)
+    {
+        var ctx = new TransformContext(formula, 1, 1, isA1: true);
+        var modifiedFormula = FormulaParser<TransformedSymbol, TransformedSymbol, TransformContext>.CellFormulaA1(formula, ctx, factory);
+        Assert.Equal(expected, modifiedFormula.ToString(string.Empty.AsSpan()));
+    }
+
+    private class FormulaFactory : FormulaGeneratorVisitor
+    {
+        public Dictionary<string, string> SheetMap { get; } = new();
+
+        protected override string ModifySheet(TransformContext ctx, string sheetName)
+        {
+            if (SheetMap.TryGetValue(sheetName, out var replacement))
+                return replacement;
+
+            return sheetName;
+        }
+    }
+}

--- a/src/ClosedXML.Parser/FormulaGeneratorVisitor.cs
+++ b/src/ClosedXML.Parser/FormulaGeneratorVisitor.cs
@@ -106,7 +106,7 @@ internal class FormulaGeneratorVisitor : IAstFactory<TransformedSymbol, Transfor
             var sheet = symbol.Slice(0, symbol.Length - REF_ERROR.Length - 1);
             var modifiedSheet = ModifySheet(ctx, sheet.ToString());
             var nodeText = new StringBuilder()
-                .AppendSheetNameWithSeparator(modifiedSheet)
+                .AppendSheetReference(modifiedSheet)
                 .Append(symbol.Slice(symbol.Length - REF_ERROR.Length))
                 .ToString();
             return TransformedSymbol.ToText(ctx.Formula, range, nodeText);
@@ -135,7 +135,7 @@ internal class FormulaGeneratorVisitor : IAstFactory<TransformedSymbol, Transfor
     {
         var sb = new StringBuilder(sheet.Length + QUOTE_RESERVE + SHEET_SEPARATOR_LEN + MAX_R1_C1_LEN);
         var nodeText = sb
-            .AppendSheetNameWithSeparator(ModifySheet(ctx, sheet))
+            .AppendSheetReference(ModifySheet(ctx, sheet))
             .AppendRef(ModifyRef(ctx, reference))
             .ToString();
         return TransformedSymbol.ToText(ctx.Formula, range, nodeText);
@@ -180,8 +180,7 @@ internal class FormulaGeneratorVisitor : IAstFactory<TransformedSymbol, Transfor
 
         var sb = new StringBuilder(BOOK_PREFIX_LEN + modifiedSheet.Length + QUOTE_RESERVE + SHEET_SEPARATOR_LEN + MAX_R1_C1_LEN);
         var nodeText = sb
-            .AppendExternalSheetName(workbookIndex, modifiedSheet)
-            .AppendReferenceSeparator()
+            .AppendExternalSheetReference(workbookIndex, modifiedSheet)
             .AppendRef(ModifyRef(ctx, reference))
             .ToString();
         return TransformedSymbol.ToText(ctx.Formula, range, nodeText);
@@ -243,7 +242,7 @@ internal class FormulaGeneratorVisitor : IAstFactory<TransformedSymbol, Transfor
 
         var sb = new StringBuilder(sheetName.Length + QUOTE_RESERVE + SHEET_SEPARATOR_LEN + functionName.Length + 2 + arguments.Sum(static x => x.Length) + arguments.Count);
         var nodeText = sb
-            .AppendSheetNameWithSeparator(modifiedSheet)
+            .AppendSheetReference(modifiedSheet)
             .AppendFunction(ctx, range, ModifyFunction(ctx, functionName), arguments)
             .ToString();
         return TransformedSymbol.ToText(ctx.Formula, range, nodeText);
@@ -257,8 +256,7 @@ internal class FormulaGeneratorVisitor : IAstFactory<TransformedSymbol, Transfor
 
         var sb = new StringBuilder(BOOK_PREFIX_LEN + modifiedSheetName.Length + QUOTE_RESERVE + SHEET_SEPARATOR_LEN + functionName.Length + 2 + arguments.Sum(static x => x.Length) + arguments.Count);
         var nodeText = sb
-            .AppendExternalSheetName(workbookIndex, modifiedSheetName)
-            .AppendReferenceSeparator()
+            .AppendExternalSheetReference(workbookIndex, modifiedSheetName)
             .AppendFunction(ctx, range, ModifyFunction(ctx, functionName), arguments)
             .ToString();
         return TransformedSymbol.ToText(ctx.Formula, range, nodeText);
@@ -312,7 +310,7 @@ internal class FormulaGeneratorVisitor : IAstFactory<TransformedSymbol, Transfor
 
         var sb = new StringBuilder(modifiedSheet.Length + QUOTE_RESERVE + SHEET_SEPARATOR_LEN + name.Length);
         var nodeText = sb
-            .AppendSheetNameWithSeparator(modifiedSheet)
+            .AppendSheetReference(modifiedSheet)
             .Append(name)
             .ToString();
         return TransformedSymbol.ToText(ctx.Formula, range, nodeText);
@@ -337,8 +335,7 @@ internal class FormulaGeneratorVisitor : IAstFactory<TransformedSymbol, Transfor
 
         var sb = new StringBuilder(BOOK_PREFIX_LEN + modifiedSheet.Length + QUOTE_RESERVE + SHEET_SEPARATOR_LEN + name.Length);
         var nodeText = sb
-            .AppendExternalSheetName(workbookIndex, modifiedSheet)
-            .AppendReferenceSeparator()
+            .AppendExternalSheetReference(workbookIndex, modifiedSheet)
             .Append(name)
             .ToString();
         return TransformedSymbol.ToText(ctx.Formula, range, nodeText);

--- a/src/ClosedXML.Parser/StringBuilderExtensions.cs
+++ b/src/ClosedXML.Parser/StringBuilderExtensions.cs
@@ -9,12 +9,7 @@ namespace ClosedXML.Parser;
 /// </summary>
 internal static class StringBuilderExtensions
 {
-    public static StringBuilder AppendSheetName(this StringBuilder sb, string sheetName)
-    {
-        return NameUtils.EscapeName(sb, sheetName);
-    }
-
-    public static StringBuilder AppendSheetNameWithSeparator(this StringBuilder sb, string? sheetName)
+    public static StringBuilder AppendSheetReference(this StringBuilder sb, string? sheetName)
     {
         if (sheetName is null)
             return sb.Append("#REF!");
@@ -22,7 +17,7 @@ internal static class StringBuilderExtensions
         return NameUtils.EscapeName(sb, sheetName).AppendReferenceSeparator();
     }
 
-    public static StringBuilder AppendExternalSheetName(this StringBuilder sb, int workbookIndex, string sheetName)
+    public static StringBuilder AppendExternalSheetReference(this StringBuilder sb, int workbookIndex, string sheetName)
     {
         if (NameUtils.ShouldQuote(sheetName.AsSpan()))
         {
@@ -30,12 +25,13 @@ internal static class StringBuilderExtensions
                 .Append('\'')
                 .AppendBookIndex(workbookIndex)
                 .AppendEscapedSheetName(sheetName)
-                .Append('\'');
+                .Append('\'')
+                .AppendReferenceSeparator();
         }
 
         return sb
             .AppendBookIndex(workbookIndex)
-            .AppendSheetName(sheetName);
+            .AppendSheetReference(sheetName);
     }
     public static StringBuilder AppendEscapedSheetName(this StringBuilder sb, string sheetName)
     {

--- a/src/ClosedXML.Parser/StringBuilderExtensions.cs
+++ b/src/ClosedXML.Parser/StringBuilderExtensions.cs
@@ -14,6 +14,14 @@ internal static class StringBuilderExtensions
         return NameUtils.EscapeName(sb, sheetName);
     }
 
+    public static StringBuilder AppendSheetNameWithSeparator(this StringBuilder sb, string? sheetName)
+    {
+        if (sheetName is null)
+            return sb.Append("#REF!");
+
+        return NameUtils.EscapeName(sb, sheetName).AppendReferenceSeparator();
+    }
+
     public static StringBuilder AppendExternalSheetName(this StringBuilder sb, int workbookIndex, string sheetName)
     {
         if (NameUtils.ShouldQuote(sheetName.AsSpan()))


### PR DESCRIPTION
The factory to create modified formula could only rename sheets, but not delete them. When sheet is deleted (indicated by modified sheet name being `null`), the result is `#REF!`.