### PR TITLE
Expose formula copy visitor

### DIFF
--- a/src/ClosedXML.Parser.Tests/RefModVisitorTests.cs
+++ b/src/ClosedXML.Parser.Tests/RefModVisitorTests.cs
@@ -60,7 +60,7 @@ public class RefModVisitorTests
     
     private static void AssertChangesA1(string formula, RefModVisitor visitor, string expected)
     {
-        var ctx = new ModContext(formula, 1, 1, isA1: true);
+        var ctx = new ModContext(formula, "Sheet", 1, 1, isA1: true);
         var modifiedFormula = FormulaParser<TransformedSymbol, TransformedSymbol, ModContext>.CellFormulaA1(formula, ctx, visitor);
         Assert.Equal(expected, modifiedFormula.ToString(string.Empty.AsSpan()));
     }

--- a/src/ClosedXML.Parser/CopyVisitor.cs
+++ b/src/ClosedXML.Parser/CopyVisitor.cs
@@ -8,7 +8,7 @@ namespace ClosedXML.Parser;
 /// <summary>
 /// A visitor that generates the identical formula for the parsed formula based on passed arguments.
 /// </summary>
-internal class CopyVisitor : IAstFactory<TransformedSymbol, TransformedSymbol, ModContext>
+public class CopyVisitor : IAstFactory<TransformedSymbol, TransformedSymbol, ModContext>
 {
     // 1 quote on left, 1 quote on right size and at most 4 quotes inside.
     private const int QUOTE_RESERVE = 6;
@@ -16,26 +16,31 @@ internal class CopyVisitor : IAstFactory<TransformedSymbol, TransformedSymbol, M
     private const int BOOK_PREFIX_LEN = 3;
     private const int MAX_R1_C1_LEN = 20;
 
+    /// <inheritdoc />
     public virtual TransformedSymbol LogicalValue(ModContext ctx, SymbolRange range, bool value)
     {
         return TransformedSymbol.CopyOriginal(ctx.Formula, range);
     }
 
+    /// <inheritdoc />
     public virtual TransformedSymbol NumberValue(ModContext ctx, SymbolRange range, double value)
     {
         return TransformedSymbol.CopyOriginal(ctx.Formula, range);
     }
 
+    /// <inheritdoc />
     public virtual TransformedSymbol TextValue(ModContext ctx, SymbolRange range, string text)
     {
         return TransformedSymbol.CopyOriginal(ctx.Formula, range);
     }
 
+    /// <inheritdoc />
     public virtual TransformedSymbol ErrorValue(ModContext ctx, SymbolRange range, ReadOnlySpan<char> error)
     {
         return TransformedSymbol.CopyOriginal(ctx.Formula, range);
     }
 
+    /// <inheritdoc />
     public virtual TransformedSymbol ArrayNode(ModContext ctx, SymbolRange range, int rows, int columns, IReadOnlyList<TransformedSymbol> elements)
     {
         var sb = new StringBuilder(2 + elements.Sum(x => x.Length) + elements.Count);
@@ -64,31 +69,37 @@ internal class CopyVisitor : IAstFactory<TransformedSymbol, TransformedSymbol, M
         return TransformedSymbol.ToText(ctx.Formula, range, nodeText);
     }
 
+    /// <inheritdoc />
     public virtual TransformedSymbol BlankNode(ModContext ctx, SymbolRange range)
     {
         return TransformedSymbol.CopyOriginal(ctx.Formula, range);
     }
 
+    /// <inheritdoc />
     public virtual TransformedSymbol LogicalNode(ModContext ctx, SymbolRange range, bool value)
     {
         return TransformedSymbol.CopyOriginal(ctx.Formula, range);
     }
 
+    /// <inheritdoc />
     public virtual TransformedSymbol ErrorNode(ModContext ctx, SymbolRange range, ReadOnlySpan<char> error)
     {
         return TransformedSymbol.CopyOriginal(ctx.Formula, range);
     }
 
+    /// <inheritdoc />
     public virtual TransformedSymbol NumberNode(ModContext ctx, SymbolRange range, double value)
     {
         return TransformedSymbol.CopyOriginal(ctx.Formula, range);
     }
 
+    /// <inheritdoc />
     public virtual TransformedSymbol TextNode(ModContext ctx, SymbolRange range, string text)
     {
         return TransformedSymbol.CopyOriginal(ctx.Formula, range);
     }
 
+    /// <inheritdoc />
     public virtual TransformedSymbol Reference(ModContext ctx, SymbolRange range, ReferenceArea reference)
     {
         var sb = new StringBuilder(MAX_R1_C1_LEN);
@@ -96,6 +107,7 @@ internal class CopyVisitor : IAstFactory<TransformedSymbol, TransformedSymbol, M
         return TransformedSymbol.ToText(ctx.Formula, range, nodeText);
     }
 
+    /// <inheritdoc />
     public virtual TransformedSymbol SheetReference(ModContext ctx, SymbolRange range, string sheet, ReferenceArea reference)
     {
         var sb = new StringBuilder(sheet.Length + QUOTE_RESERVE + SHEET_SEPARATOR_LEN + MAX_R1_C1_LEN);
@@ -106,6 +118,7 @@ internal class CopyVisitor : IAstFactory<TransformedSymbol, TransformedSymbol, M
         return TransformedSymbol.ToText(ctx.Formula, range, nodeText);
     }
 
+    /// <inheritdoc />
     public virtual TransformedSymbol Reference3D(ModContext ctx, SymbolRange range, string firstSheet, string lastSheet, ReferenceArea reference)
     {
         var sb = new StringBuilder(firstSheet.Length + QUOTE_RESERVE + lastSheet.Length + QUOTE_RESERVE + SHEET_SEPARATOR_LEN + MAX_R1_C1_LEN);
@@ -132,6 +145,7 @@ internal class CopyVisitor : IAstFactory<TransformedSymbol, TransformedSymbol, M
         return TransformedSymbol.ToText(ctx.Formula, range, nodeText);
     }
 
+    /// <inheritdoc />
     public virtual TransformedSymbol ExternalSheetReference(ModContext ctx, SymbolRange range, int workbookIndex, string sheet, ReferenceArea reference)
     {
         var sb = new StringBuilder(BOOK_PREFIX_LEN + sheet.Length + QUOTE_RESERVE + SHEET_SEPARATOR_LEN + MAX_R1_C1_LEN);
@@ -142,6 +156,7 @@ internal class CopyVisitor : IAstFactory<TransformedSymbol, TransformedSymbol, M
         return TransformedSymbol.ToText(ctx.Formula, range, nodeText);
     }
 
+    /// <inheritdoc />
     public virtual TransformedSymbol ExternalReference3D(ModContext ctx, SymbolRange range, int workbookIndex, string firstSheet, string lastSheet, ReferenceArea reference)
     {
         var sb = new StringBuilder(BOOK_PREFIX_LEN + firstSheet.Length + QUOTE_RESERVE + lastSheet.Length + QUOTE_RESERVE + SHEET_SEPARATOR_LEN + MAX_R1_C1_LEN);
@@ -171,6 +186,7 @@ internal class CopyVisitor : IAstFactory<TransformedSymbol, TransformedSymbol, M
         return TransformedSymbol.ToText(ctx.Formula, range, nodeText);
     }
 
+    /// <inheritdoc />
     public virtual TransformedSymbol Function(ModContext ctx, SymbolRange range, ReadOnlySpan<char> functionName, IReadOnlyList<TransformedSymbol> arguments)
     {
         var sb = new StringBuilder(functionName.Length + 2 + arguments.Sum(static x => x.Length) + arguments.Count);
@@ -178,6 +194,7 @@ internal class CopyVisitor : IAstFactory<TransformedSymbol, TransformedSymbol, M
         return TransformedSymbol.ToText(ctx.Formula, range, nodeText);
     }
 
+    /// <inheritdoc />
     public virtual TransformedSymbol ExternalFunction(ModContext ctx, SymbolRange range, int workbookIndex, ReadOnlySpan<char> functionName, IReadOnlyList<TransformedSymbol> arguments)
     {
         var sb = new StringBuilder(BOOK_PREFIX_LEN + functionName.Length + 2 + arguments.Sum(static x => x.Length) + arguments.Count);
@@ -189,6 +206,7 @@ internal class CopyVisitor : IAstFactory<TransformedSymbol, TransformedSymbol, M
         return TransformedSymbol.ToText(ctx.Formula, range, nodeText);
     }
 
+    /// <inheritdoc />
     public virtual TransformedSymbol Function(ModContext ctx, SymbolRange range, string sheetName, ReadOnlySpan<char> functionName, IReadOnlyList<TransformedSymbol> arguments)
     {
         var sb = new StringBuilder(sheetName.Length + QUOTE_RESERVE + SHEET_SEPARATOR_LEN + functionName.Length + 2 + arguments.Sum(static x => x.Length) + arguments.Count);
@@ -199,6 +217,7 @@ internal class CopyVisitor : IAstFactory<TransformedSymbol, TransformedSymbol, M
         return TransformedSymbol.ToText(ctx.Formula, range, nodeText);
     }
 
+    /// <inheritdoc />
     public virtual TransformedSymbol ExternalFunction(ModContext ctx, SymbolRange range, int workbookIndex, string sheetName, ReadOnlySpan<char> functionName, IReadOnlyList<TransformedSymbol> arguments)
     {
         var sb = new StringBuilder(BOOK_PREFIX_LEN + sheetName.Length + QUOTE_RESERVE + SHEET_SEPARATOR_LEN + functionName.Length + 2 + arguments.Sum(static x => x.Length) + arguments.Count);
@@ -209,6 +228,7 @@ internal class CopyVisitor : IAstFactory<TransformedSymbol, TransformedSymbol, M
         return TransformedSymbol.ToText(ctx.Formula, range, nodeText);
     }
 
+    /// <inheritdoc />
     public virtual TransformedSymbol CellFunction(ModContext ctx, SymbolRange range, RowCol cell, IReadOnlyList<TransformedSymbol> arguments)
     {
         var sb = new StringBuilder(MAX_R1_C1_LEN + SHEET_SEPARATOR_LEN + arguments.Sum(static x => x.Length));
@@ -219,6 +239,7 @@ internal class CopyVisitor : IAstFactory<TransformedSymbol, TransformedSymbol, M
         return TransformedSymbol.ToText(ctx.Formula, range, nodeText);
     }
 
+    /// <inheritdoc />
     public virtual TransformedSymbol StructureReference(ModContext ctx, SymbolRange range,
         StructuredReferenceArea area, string? firstColumn, string? lastColumn)
     {
@@ -226,6 +247,7 @@ internal class CopyVisitor : IAstFactory<TransformedSymbol, TransformedSymbol, M
         return TransformedSymbol.ToText(ctx.Formula, range, nodeText);
     }
 
+    /// <inheritdoc />
     public virtual TransformedSymbol StructureReference(ModContext ctx, SymbolRange range,
         string table, StructuredReferenceArea area, string? firstColumn, string? lastColumn)
     {
@@ -233,6 +255,7 @@ internal class CopyVisitor : IAstFactory<TransformedSymbol, TransformedSymbol, M
         return TransformedSymbol.ToText(ctx.Formula, range, nodeText);
     }
 
+    /// <inheritdoc />
     public virtual TransformedSymbol ExternalStructureReference(ModContext ctx,
         SymbolRange range, int workbookIndex, string table, StructuredReferenceArea area, string? firstColumn,
         string? lastColumn)
@@ -244,11 +267,13 @@ internal class CopyVisitor : IAstFactory<TransformedSymbol, TransformedSymbol, M
         return TransformedSymbol.ToText(ctx.Formula, range, nodeText);
     }
 
+    /// <inheritdoc />
     public virtual TransformedSymbol Name(ModContext ctx, SymbolRange range, string name)
     {
         return TransformedSymbol.CopyOriginal(ctx.Formula, range);
     }
 
+    /// <inheritdoc />
     public virtual TransformedSymbol SheetName(ModContext ctx, SymbolRange range, string sheet, string name)
     {
         var sb = new StringBuilder(sheet.Length + QUOTE_RESERVE + SHEET_SEPARATOR_LEN + name.Length);
@@ -259,6 +284,7 @@ internal class CopyVisitor : IAstFactory<TransformedSymbol, TransformedSymbol, M
         return TransformedSymbol.ToText(ctx.Formula, range, nodeText);
     }
 
+    /// <inheritdoc />
     public virtual TransformedSymbol ExternalName(ModContext ctx, SymbolRange range, int workbookIndex, string name)
     {
         var sb = new StringBuilder(BOOK_PREFIX_LEN + SHEET_SEPARATOR_LEN + name.Length);
@@ -270,6 +296,7 @@ internal class CopyVisitor : IAstFactory<TransformedSymbol, TransformedSymbol, M
         return TransformedSymbol.ToText(ctx.Formula, range, nodeText);
     }
 
+    /// <inheritdoc />
     public virtual TransformedSymbol ExternalSheetName(ModContext ctx, SymbolRange range, int workbookIndex, string sheet, string name)
     {
         var sb = new StringBuilder(BOOK_PREFIX_LEN + sheet.Length + QUOTE_RESERVE + SHEET_SEPARATOR_LEN + name.Length);
@@ -280,6 +307,7 @@ internal class CopyVisitor : IAstFactory<TransformedSymbol, TransformedSymbol, M
         return TransformedSymbol.ToText(ctx.Formula, range, nodeText);
     }
 
+    /// <inheritdoc />
     public virtual TransformedSymbol BinaryNode(ModContext ctx, SymbolRange range, BinaryOperation operation, TransformedSymbol leftNode, TransformedSymbol rightNode)
     {
         var sb = new StringBuilder(leftNode.Length + rightNode.OriginalRange.Start - leftNode.OriginalRange.End + rightNode.Length)
@@ -293,6 +321,7 @@ internal class CopyVisitor : IAstFactory<TransformedSymbol, TransformedSymbol, M
         return TransformedSymbol.ToText(ctx.Formula, range, nodeText);
     }
 
+    /// <inheritdoc />
     public virtual TransformedSymbol Unary(ModContext ctx, SymbolRange range, UnaryOperation operation, TransformedSymbol node)
     {
         var sb = new StringBuilder(node.Length + 1)
@@ -304,6 +333,7 @@ internal class CopyVisitor : IAstFactory<TransformedSymbol, TransformedSymbol, M
         return TransformedSymbol.ToText(ctx.Formula, range, nodeText);
     }
 
+    /// <inheritdoc />
     public virtual TransformedSymbol Nested(ModContext ctx, SymbolRange range, TransformedSymbol node)
     {
         var nodeText = new StringBuilder(node.Length + 2)

--- a/src/ClosedXML.Parser/FormulaConverter.cs
+++ b/src/ClosedXML.Parser/FormulaConverter.cs
@@ -22,7 +22,7 @@ public static class FormulaConverter
     /// <exception cref="ParsingException">The formula is not parseable.</exception>
     public static string ToR1C1(string formulaA1, int row, int col)
     {
-        var ctx = new ModContext(formulaA1, row, col, isA1: true);
+        var ctx = new ModContext(formulaA1, string.Empty, row, col, isA1: true);
         var transformedFormula = FormulaParser<TransformedSymbol, TransformedSymbol, ModContext>.CellFormulaA1(formulaA1, ctx, s_visitorR1C1);
         return Normalize(transformedFormula, formulaA1);
     }
@@ -37,7 +37,7 @@ public static class FormulaConverter
     /// <exception cref="ParsingException">The formula is not parseable.</exception>
     public static string ToA1(string formulaR1C1, int row, int col)
     {
-        var ctx = new ModContext(formulaR1C1, row, col, isA1: false);
+        var ctx = new ModContext(formulaR1C1, string.Empty, row, col, isA1: false);
         var transformedFormula = FormulaParser<TransformedSymbol, TransformedSymbol, ModContext>.CellFormulaR1C1(formulaR1C1, ctx, s_visitorA1);
         return Normalize(transformedFormula, formulaR1C1);
     }
@@ -49,9 +49,23 @@ public static class FormulaConverter
     /// <param name="row">Row number of formula.</param>
     /// <param name="col">Column number of formula.</param>
     /// <param name="factory">Visitor to transform the formula.</param>
+    [Obsolete("Use overload with sheet parameter.")]
     public static string ModifyA1(string formulaA1, int row, int col, IAstFactory<TransformedSymbol, TransformedSymbol, ModContext> factory)
     {
-        var ctx = new ModContext(formulaA1, row, col, isA1: true);
+        return ModifyA1(formulaA1, string.Empty, row, col, factory);
+    }
+
+    /// <summary>
+    /// Modify the formula using the passed <paramref name="factory"/>.
+    /// </summary>
+    /// <param name="formulaA1">Original formula in A1 style.</param>
+    /// <param name="sheet">Name of the sheet where is the formula.</param>
+    /// <param name="row">Row number of formula.</param>
+    /// <param name="col">Column number of formula.</param>
+    /// <param name="factory">Visitor to transform the formula.</param>
+    public static string ModifyA1(string formulaA1, string sheet, int row, int col, IAstFactory<TransformedSymbol, TransformedSymbol, ModContext> factory)
+    {
+        var ctx = new ModContext(formulaA1, sheet, row, col, isA1: true);
         var transformedFormula = FormulaParser<TransformedSymbol, TransformedSymbol, ModContext>.CellFormulaA1(formulaA1, ctx, factory);
         return Normalize(transformedFormula, formulaA1);
     }

--- a/src/ClosedXML.Parser/ModContext.cs
+++ b/src/ClosedXML.Parser/ModContext.cs
@@ -10,7 +10,16 @@ public class ModContext
     /// <summary>
     /// Create a context for modifying formulas. 
     /// </summary>
+    [Obsolete("Use overload with sheet parameter.")]
     public ModContext(string formula, int row, int col, bool isA1)
+        : this(formula, string.Empty, row, col, isA1)
+    {
+    }
+
+    /// <summary>
+    /// Create a context for modifying formulas. 
+    /// </summary>
+    public ModContext(string formula, string sheet, int row, int col, bool isA1)
     {
         if (string.IsNullOrWhiteSpace(formula))
             throw new ArgumentException(nameof(formula));
@@ -22,6 +31,7 @@ public class ModContext
             throw new ArgumentOutOfRangeException(nameof(row));
 
         Formula = formula;
+        Sheet = sheet;
         Row = row;
         Col = col;
         IsA1 = isA1;
@@ -31,6 +41,11 @@ public class ModContext
     /// The original formula without any modifications.
     /// </summary>
     public string Formula { get; }
+
+    /// <summary>
+    /// Name of the current sheet.
+    /// </summary>
+    public string Sheet { get; }
 
     /// <summary>
     /// Absolute row number in a sheet.


### PR DESCRIPTION
Copy visitor will be used by consumers to do things like shift references and so on. That is not currently possible, because RefModVisitor doesn't expose methods to modify references and even if it did, there is idea to know if reference is from sheet reference or 3D reference.

Also, add info about current sheet to the context, so visitor knows implicit sheet for non-sheet references (e.g. pure `A1`). In some places, I have used string.Empty, because that will never conflict with any sheet name (empty name is invalid sheet name).