### PR TITLE
ReferenceArea To A1 logic

### DIFF
--- a/src/ClosedXML.Parser/ClosedXML.Parser.csproj
+++ b/src/ClosedXML.Parser/ClosedXML.Parser.csproj
@@ -17,7 +17,7 @@
     <PackageProjectUrl>https://github.com/ClosedXML/ClosedXML.Parser</PackageProjectUrl>
     <RepositoryUrl>https://github.com/ClosedXML/ClosedXML.Parser</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageVersion>1.2.0</PackageVersion>
+    <PackageVersion>1.3.0</PackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/src/ClosedXML.Parser/ReferenceArea.cs
+++ b/src/ClosedXML.Parser/ReferenceArea.cs
@@ -107,14 +107,7 @@ public readonly struct ReferenceArea
     /// </summary>
     public string GetDisplayStringR1C1()
     {
-        if (First == Second)
-            return First.GetDisplayStringR1C1();
-
-        return new StringBuilder()
-            .Append(First.GetDisplayStringR1C1())
-            .Append(':')
-            .Append(Second.GetDisplayStringR1C1())
-            .ToString();
+        return AppendR1C1(new StringBuilder()).ToString();
     }
 
     /// <summary>

--- a/src/ClosedXML.Parser/ReferenceArea.cs
+++ b/src/ClosedXML.Parser/ReferenceArea.cs
@@ -32,6 +32,16 @@ public readonly struct ReferenceArea
     public ReferenceStyle Style => First.Style;
 
     /// <summary>
+    /// Is area a row span (e.g. <c>$5:7</c> in A1 or <c>R[7]</c>, <c>R7:R[9]</c>)?
+    /// </summary>
+    internal bool IsRowSpan => First.IsRow && Second.IsRow;
+
+    /// <summary>
+    /// Is area a col span (e.g. <c>$C:Z</c> in A1 or <c>C[7]</c>, <c>C7:C[9]</c>)?
+    /// </summary>
+    internal bool IsColSpan => First.IsColumn && Second.IsColumn;
+
+    /// <summary>
     /// Create a reference symbol using the two <see cref="RowCol"/> (e.g.
     /// <c>A1:B2</c>) or two columns (e.g. <c>A:D</c>) or two rows (e.g.
     /// <c>7:8</c>).
@@ -85,14 +95,9 @@ public readonly struct ReferenceArea
     /// </summary>
     public string GetDisplayStringA1()
     {
-        if (First == Second && !First.IsColumn && !First.IsRow)
-            return First.GetDisplayStringA1();
-
-        return new StringBuilder()
-            .Append(First.GetDisplayStringA1())
-            .Append(':')
-            .Append(Second.GetDisplayStringA1())
-            .ToString();
+        var sb = new StringBuilder();
+        AppendA1(sb);
+        return sb.ToString();
     }
 
     /// <summary>
@@ -156,14 +161,13 @@ public readonly struct ReferenceArea
     /// <remarks>Assumes reference is in A1.</remarks>
     internal StringBuilder AppendA1(StringBuilder sb)
     {
+        // In A1, column and row span must have both parts specified.
+        if (First == Second && !IsColSpan && !IsRowSpan)
+            return First.AppendA1(sb);
+
         First.AppendA1(sb);
-
-        if (First != Second)
-        {
-            sb.Append(':');
-            Second.AppendA1(sb);
-        }
-
+        sb.Append(':');
+        Second.AppendA1(sb);
         return sb;
     }
 

--- a/src/ClosedXML.Parser/RowCol.cs
+++ b/src/ClosedXML.Parser/RowCol.cs
@@ -296,7 +296,7 @@ public readonly struct RowCol : IEquatable<RowCol>
     /// <inheritdoc cref="GetDisplayStringA1()"/>
     /// <param name="sb">String buffer where to write the output.</param>
     /// <exception cref="InvalidOperationException">When <c>RowCol</c> is not in <em>A1</em> notation.</exception>
-    internal void AppendA1(StringBuilder sb)
+    internal StringBuilder AppendA1(StringBuilder sb)
     {
         if (!IsA1)
             throw new InvalidOperationException("RowCol doesn't use A1 semantic.");
@@ -334,6 +334,8 @@ public readonly struct RowCol : IEquatable<RowCol>
             default:
                 throw new NotSupportedException();
         }
+
+        return sb;
     }
 
     /// <inheritdoc cref="GetDisplayStringR1C1()"/>


### PR DESCRIPTION
Logic should be same for GetDisplayStringA1 and AppendA1, dtto for R1C1 logic. Public API is already tested by `ReferenceAreaTests`, so no need to add tests.

Fixes https://github.com/ClosedXML/ClosedXML/issues/2472