### PR TITLE
Add support for bang reference

### DIFF
--- a/src/ClosedXML.Parser.Ast/AstFactory.cs
+++ b/src/ClosedXML.Parser.Ast/AstFactory.cs
@@ -64,6 +64,11 @@ public class F : IAstFactory<ScalarValue, AstNode, Ctx>
         return new SheetReferenceNode(sheet, reference);
     }
 
+    public AstNode BangReference(Ctx _, SymbolRange range, ReferenceArea reference)
+    {
+        return new BangReferenceNode(reference);
+    }
+
     public AstNode Reference3D(Ctx _, SymbolRange range, string firstSheet, string lastSheet, ReferenceArea reference)
     {
         return new Reference3DNode(firstSheet, lastSheet, reference);

--- a/src/ClosedXML.Parser.Ast/BangReferenceNode.cs
+++ b/src/ClosedXML.Parser.Ast/BangReferenceNode.cs
@@ -1,0 +1,9 @@
+﻿namespace ClosedXML.Parser;
+
+public record BangReferenceNode(ReferenceArea Reference) : AstNode
+{
+    public override string GetDisplayString(ReferenceStyle style)
+    {
+        return $"!{Reference.GetDisplayString(style)}";
+    }
+}

--- a/src/ClosedXML.Parser.Tests/AntlrCompatibilityTests.cs
+++ b/src/ClosedXML.Parser.Tests/AntlrCompatibilityTests.cs
@@ -10,6 +10,7 @@ public class AntlrCompatibilityTests
     [Theory]
     [InlineData("./data/enron/formulas.csv")]
     [InlineData("./data/euses/formulas.csv")]
+    [InlineData("./data/contributions/formulas.csv")]
     public void Produce_same_tokens_for_data_sets(string dataSetFile)
     {
         foreach (var formula in DataSets.ReadCsv(dataSetFile))

--- a/src/ClosedXML.Parser.Tests/AstFactoryTests.cs
+++ b/src/ClosedXML.Parser.Tests/AstFactoryTests.cs
@@ -73,6 +73,16 @@ public class AstFactoryTests
     }
 
     [Theory]
+    [InlineData("name + !$A$1:$B4 ", 7, 16)]
+    [InlineData("1+!$Z$26", 2, 8)]
+    public void BangReferenceRange(string formula, int start, int end)
+    {
+        var result = new Result();
+        FormulaParser<object?, string, Result>.CellFormulaA1(formula, result, new BangReferenceVisitor());
+        Assert.Equal(new SymbolRange(start, end), result.Value);
+    }
+
+    [Theory]
     [InlineData("Jan:Feb!A1", 0, 10)]
     [InlineData("1+Zara:Beta!$A$1:$B4+4", 2, 20)]
     [InlineData("1+'2022 Q1:2024 Q1'!Z26", 2, 23)]
@@ -292,6 +302,15 @@ public class AstFactoryTests
     private class SheetReferenceVisitor : BaseVisitor
     {
         public override string SheetReference(Result context, SymbolRange range, string sheet, ReferenceArea reference)
+        {
+            context.Value = range;
+            return string.Empty;
+        }
+    }
+
+    private class BangReferenceVisitor : BaseVisitor
+    {
+        public override string BangReference(Result context, SymbolRange range, ReferenceArea reference)
         {
             context.Value = range;
             return string.Empty;
@@ -552,6 +571,11 @@ public class AstFactoryTests
         }
 
         public virtual TNode SheetReference(TContext context, SymbolRange range, string sheet, ReferenceArea reference)
+        {
+            return _defaultNode;
+        }
+
+        public virtual TNode BangReference(TContext context, SymbolRange range, ReferenceArea reference)
         {
             return _defaultNode;
         }

--- a/src/ClosedXML.Parser.Tests/DataSetTests.cs
+++ b/src/ClosedXML.Parser.Tests/DataSetTests.cs
@@ -36,6 +36,12 @@ public class DataSetTests
             });
     }
 
+    [Fact]
+    public void Contributions_data_set_is_parseable()
+    {
+        Assert_formulas_parsed_or_not_as_expected("./data/contributions/formulas.csv", Array.Empty<string>());
+    }
+
     private void Assert_formulas_parsed_or_not_as_expected(string input, string[] badFormulaPaths)
     {
         var badFormulas = new HashSet<string>();

--- a/src/ClosedXML.Parser.Tests/Rules/RefAtomExpressionRuleTests.cs
+++ b/src/ClosedXML.Parser.Tests/Rules/RefAtomExpressionRuleTests.cs
@@ -62,6 +62,18 @@ public class RefAtomExpressionRuleTests
     }
 
     [Fact]
+    public void Bang_reference()
+    {
+        VerifyNode("!$A7:$D$9", new BangReferenceNode(ReferenceParser.ParseA1("$A7:$D$9")));
+    }
+
+    [Fact]
+    public void Bang_reference_error()
+    {
+        VerifyNode("!#REF!", new ValueNode("Error", "#REF!"));
+    }
+
+    [Fact]
     public void Sheet_reference_can_have_whitespace_after_exclamation_mark()
     {
         VerifyNode("Sheet2!  A1", new SheetReferenceNode("Sheet2", new ReferenceArea(1, 1, A1)));

--- a/src/ClosedXML.Parser.Tests/data/contributions/formulas.csv
+++ b/src/ClosedXML.Parser.Tests/data/contributions/formulas.csv
@@ -1,0 +1,1 @@
+"OFFSET('Smelter Look-up'!$B$4,MATCH(!$B1,'Smelter Look-up'!$A:$A,0)-4,0,COUNTIF('Smelter Look-up'!$A:$A,!$B1),1)"

--- a/src/ClosedXML.Parser/ClosedXML.Parser.csproj
+++ b/src/ClosedXML.Parser/ClosedXML.Parser.csproj
@@ -17,7 +17,7 @@
     <PackageProjectUrl>https://github.com/ClosedXML/ClosedXML.Parser</PackageProjectUrl>
     <RepositoryUrl>https://github.com/ClosedXML/ClosedXML.Parser</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageVersion>1.3.0</PackageVersion>
+    <PackageVersion>2.0.0-preview1</PackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/src/ClosedXML.Parser/CopyVisitor.cs
+++ b/src/ClosedXML.Parser/CopyVisitor.cs
@@ -119,6 +119,16 @@ public class CopyVisitor : IAstFactory<TransformedSymbol, TransformedSymbol, Mod
     }
 
     /// <inheritdoc />
+    public virtual TransformedSymbol BangReference(ModContext ctx, SymbolRange range, ReferenceArea reference)
+    {
+        var sb = new StringBuilder(SHEET_SEPARATOR_LEN + MAX_R1_C1_LEN);
+        var nodeText = sb
+            .AppendReferenceSeparator()
+            .AppendRef(reference)
+            .ToString();
+        return TransformedSymbol.ToText(ctx.Formula, range, nodeText);
+    }
+
     public virtual TransformedSymbol Reference3D(ModContext ctx, SymbolRange range, string firstSheet, string lastSheet, ReferenceArea reference)
     {
         var sb = new StringBuilder(firstSheet.Length + QUOTE_RESERVE + lastSheet.Length + QUOTE_RESERVE + SHEET_SEPARATOR_LEN + MAX_R1_C1_LEN);

--- a/src/ClosedXML.Parser/IAstFactory.cs
+++ b/src/ClosedXML.Parser/IAstFactory.cs
@@ -123,6 +123,18 @@ public interface IAstFactory<TScalarValue, TNode, in TContext>
     TNode SheetReference(TContext context, SymbolRange range, string sheet, ReferenceArea reference);
 
     /// <summary>
+    /// Create a node that processes a bang reference in a formula (e.g <c>"Branch:" &amp; !$C$5</c>). Bang reference should
+    /// <list>
+    ///   <item>Be used only in defined names.</item>
+    ///   <item>Always be absolute (name doesn't have an anchor).</item>
+    /// </list>
+    /// </summary>
+    /// <param name="context">User supplied context for parsing a tree that is an argument of a parsing method.</param>
+    /// <param name="range">Range in a formula that contains the bang reference.</param>
+    /// <param name="reference">Area in the sheet.</param>
+    TNode BangReference(TContext context, SymbolRange range, ReferenceArea reference);
+
+    /// <summary>
     /// Create a node for a 3D reference.
     /// </summary>
     /// <param name="context">User supplied context for parsing a tree that is an argument of a parsing method.</param>

--- a/src/ClosedXML.Parser/RefModVisitor.cs
+++ b/src/ClosedXML.Parser/RefModVisitor.cs
@@ -11,6 +11,7 @@ namespace ClosedXML.Parser;
 public class RefModVisitor : IAstFactory<TransformedSymbol, TransformedSymbol, ModContext>
 {
     private const string REF_ERROR = "#REF!";
+    private const string BANG_REF_ERROR = "!#REF!";
     private static readonly CopyVisitor s_copyVisitor = new();
 
     /// <inheritdoc />
@@ -114,6 +115,16 @@ public class RefModVisitor : IAstFactory<TransformedSymbol, TransformedSymbol, M
             return TransformedSymbol.ToText(ctx.Formula, range, REF_ERROR);
 
         return s_copyVisitor.SheetReference(ctx, range, modifiedSheet, modifiedReference.Value);
+    }
+
+    /// <inheritdoc />
+    public TransformedSymbol BangReference(ModContext ctx, SymbolRange range, ReferenceArea reference)
+    {
+        var modifiedReference = ModifyRef(ctx, reference);
+        if (modifiedReference is null)
+            return TransformedSymbol.ToText(ctx.Formula, range, BANG_REF_ERROR);
+
+        return s_copyVisitor.BangReference(ctx, range, modifiedReference.Value);
     }
 
     /// <inheritdoc />

--- a/src/ClosedXML.Parser/ReferenceArea.cs
+++ b/src/ClosedXML.Parser/ReferenceArea.cs
@@ -1,8 +1,5 @@
-﻿using ClosedXML.Parser.Rolex;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.Text;
-using JetBrains.Annotations;
 
 namespace ClosedXML.Parser;
 
@@ -11,7 +8,7 @@ namespace ClosedXML.Parser;
 /// an area in a sheet. This is the DTO from parser to engine. Two corners make an area
 /// for A1 notation, but not for R1C1 (has several edge cases).
 /// </summary>
-public readonly struct ReferenceArea
+public readonly record struct ReferenceArea
 {
     /// <summary>
     /// First reference. First in terms of position in formula, not position


### PR DESCRIPTION
This node should only be present in the name formula, but that is not checked.

Fixes #19 