### PR TITLE
Fix function extension point

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
     - name: Restore dependencies
       run: dotnet restore src/ClosedXML.Parser.sln
     - name: Build

--- a/src/ClosedXML.ANTLR/ClosedXML.ANTLR.csproj
+++ b/src/ClosedXML.ANTLR/ClosedXML.ANTLR.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/ClosedXML.Parser.Ast/ClosedXML.Parser.Ast.csproj
+++ b/src/ClosedXML.Parser.Ast/ClosedXML.Parser.Ast.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>ClosedXML.Parser</RootNamespace>

--- a/src/ClosedXML.Parser.Function/ClosedXML.Parser.Function.csproj
+++ b/src/ClosedXML.Parser.Function/ClosedXML.Parser.Function.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
 
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.1" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.6.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClosedXML.Parser.Ast\ClosedXML.Parser.Ast.csproj" />

--- a/src/ClosedXML.Parser.Tests/ClosedXML.Parser.Tests.csproj
+++ b/src/ClosedXML.Parser.Tests/ClosedXML.Parser.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/src/ClosedXML.Parser/CopyVisitor.cs
+++ b/src/ClosedXML.Parser/CopyVisitor.cs
@@ -7,6 +7,8 @@ namespace ClosedXML.Parser;
 
 /// <summary>
 /// A visitor that generates the identical formula for the parsed formula based on passed arguments.
+/// CopyVisitor doesn't make any judgements if passed arguments have been modified. It just makes
+/// a newly allocated copy based on passed values.
 /// </summary>
 public class CopyVisitor : IAstFactory<TransformedSymbol, TransformedSymbol, ModContext>
 {

--- a/src/ClosedXML.Parser/RefModVisitor.cs
+++ b/src/ClosedXML.Parser/RefModVisitor.cs
@@ -153,18 +153,18 @@ public class RefModVisitor : IAstFactory<TransformedSymbol, TransformedSymbol, M
     /// <inheritdoc />
     public TransformedSymbol Function(ModContext ctx, SymbolRange range, ReadOnlySpan<char> functionName, IReadOnlyList<TransformedSymbol> arguments)
     {
-        return s_copyVisitor.Function(ctx, range, functionName, arguments);
+        var modifiedFunction = ModifyFunction(ctx, functionName);
+        return s_copyVisitor.Function(ctx, range, modifiedFunction, arguments);
     }
 
     /// <inheritdoc />
     public TransformedSymbol Function(ModContext ctx, SymbolRange range, string sheetName, ReadOnlySpan<char> functionName, IReadOnlyList<TransformedSymbol> arguments)
     {
-        var modifiedFunction = ModifyFunction(ctx, functionName);
         var modifiedSheet = ModifySheet(ctx, sheetName);
         if (modifiedSheet is null)
             return TransformedSymbol.ToText(ctx.Formula, range, REF_ERROR);
 
-        return s_copyVisitor.Function(ctx, range, modifiedSheet, modifiedFunction, arguments);
+        return s_copyVisitor.Function(ctx, range, modifiedSheet, functionName, arguments);
     }
 
     /// <inheritdoc />
@@ -280,7 +280,7 @@ public class RefModVisitor : IAstFactory<TransformedSymbol, TransformedSymbol, M
     }
 
     /// <summary>
-    /// An extension to modify name of a function.
+    /// An extension to modify name of a function. Doesn't modify the sheet/external functions.
     /// </summary>
     /// <param name="ctx">The transformation context.</param>
     /// <param name="functionName">Original name of function.</param>


### PR DESCRIPTION
The extension point should be for normal global functions, not sheet scoped functions (i.e. VBA stuff) or external functions.

It's purpose is to fix function names, like future functions.