### PR TITLE
LOG10 function is not a cell func

### DIFF
--- a/src/ClosedXML.Parser.Tests/RefModVisitorTests.cs
+++ b/src/ClosedXML.Parser.Tests/RefModVisitorTests.cs
@@ -71,6 +71,13 @@ public class RefModVisitorTests
         AssertChangesA1(formula, factory, modifiedFormula);
     }
 
+    [Fact]
+    public void Log10_is_not_interpreted_as_cell_function()
+    {
+        var factory = new ShiftReferenceVisitor { ReferenceMap = { { "LOG10", "A1"} } };
+        AssertChangesA1("LOG10(LOG10)", factory, "LOG10(A1)");
+    }
+
     private static void AssertChangesA1(string formula, RefModVisitor visitor, string expected)
     {
         var ctx = new ModContext(formula, "Sheet", 1, 1, isA1: true);
@@ -98,6 +105,14 @@ public class RefModVisitorTests
                 return replacement is not null ? ReferenceParser.ParseA1(replacement) : null;
 
             return reference;
+        }
+
+        internal override RowCol? ModifyCellFunction(ModContext ctx, RowCol cell)
+        {
+            if (ReferenceMap.TryGetValue(cell.GetDisplayStringA1(), out var replacement))
+                return replacement is not null ? ReferenceParser.ParseA1(replacement).First : null;
+
+            return cell;
         }
     }
 }

--- a/src/ClosedXML.Parser/RefModVisitor.cs
+++ b/src/ClosedXML.Parser/RefModVisitor.cs
@@ -193,6 +193,15 @@ public class RefModVisitor : IAstFactory<TransformedSymbol, TransformedSymbol, M
     /// <inheritdoc />
     public TransformedSymbol CellFunction(ModContext ctx, SymbolRange range, RowCol cell, IReadOnlyList<TransformedSymbol> arguments)
     {
+        // Parser doesn't detect LOG10 as a function (there is no list of functions),
+        // but as a cell function. Make sure not to transform it.
+        var functionName = ctx.Formula.AsSpan(range.Start, ctx.Formula.IndexOf('(', range.Start) - range.Start);
+        if (functionName.Equals("LOG10".AsSpan(), StringComparison.OrdinalIgnoreCase))
+        {
+            var modifiedName = ModifyFunction(ctx, functionName);
+            return s_copyVisitor.Function(ctx, range, modifiedName, arguments);
+        }
+
         var modifiedCell = ModifyCellFunction(ctx, cell);
         if (modifiedCell is null)
             return TransformedSymbol.ToText(ctx.Formula, range, REF_ERROR);


### PR DESCRIPTION
Parser accepts cell references as functions, e.g. `$A$1(45)`. When formula is converted between `A1` and `R1C1`, make sure the `LOG10` is *not* interpreted as a cell function. That would  cause all sorts of problems with shifting or deleting areas.

Example: `LOG10` would be turned to R1C1, the R1C1 reference would shift and then be turned back. Except not as a `LOG10`, but as `LOG11`.