### PR TITLE
A lexer for 3.0

### DIFF
--- a/src/ClosedXML.Parser.Tests/Lexers/LexerTests.cs
+++ b/src/ClosedXML.Parser.Tests/Lexers/LexerTests.cs
@@ -1,0 +1,330 @@
+﻿using ClosedXML.Parser.Pratt;
+
+namespace ClosedXML.Parser.Tests.Lexers;
+
+public class LexerTests
+{
+    // ( [0-9] )+
+    [InlineData("0")]
+    [InlineData("1")]
+    [InlineData("90")]
+    [InlineData("00050")]
+
+    // ( [0-9] )+ '.' ( [0-9]] )+
+    [InlineData("0.0")]
+    [InlineData("1.2")]
+    [InlineData("0010.0020")]
+    [InlineData("999.99")]
+
+    // '.' ( [0-9]] )+
+    [InlineData(".0")]
+    [InlineData(".1")]
+    [InlineData(".0001")]
+    [InlineData(".987")]
+
+    // ( [0-9] )+ [Ee] ( [0-9]] )+
+    [InlineData("0e0")]
+    [InlineData("0E0")]
+    [InlineData("1e2")]
+    [InlineData("1E2")]
+    [InlineData("987e12")]
+
+    // ( [0-9] )+ '.' ( [0-9]] )+ [Ee] ( [0-9]] )+
+    [InlineData("0.0e4")]
+    [InlineData("12.724e13")]
+    [InlineData("12.3E2")]
+
+    // '.' ( [0-9]] )+ [Ee] ( [0-9]] )+
+    [InlineData(".0e0")]
+    [InlineData(".1e2")]
+    [InlineData(".987e54")]
+
+    // ( [0-9] )+ [Ee] [+-] ( [0-9]] )+
+    [InlineData("1e+7")]
+    [InlineData("74e-32")]
+    [InlineData("15E-0")]
+    [InlineData("0e+0")]
+    [InlineData("01e+7")]
+
+    // ( [0-9] )+ '.' ( [0-9]] )+ [Ee] [+-] ( [0-9]] )+
+    [InlineData("0.0e+0")]
+    [InlineData("1.2e+3")]
+    [InlineData("01.2e+3")]
+    [InlineData("1.2E+3")]
+    [InlineData("12.34e+56")]
+
+    // '.' ( [0-9]] )+ [Ee] [+-] ( [0-9]] )+
+    [InlineData(".0e+0")]
+    [InlineData(".1e+2")]
+    [InlineData(".12E+34")]
+    [InlineData(".012e+034")]
+    [Theory]
+    public void Number_ok(string input)
+    {
+        AssertToken(TokenType.Number, input);
+    }
+
+    [InlineData("0e+")]
+    [InlineData(".0e+")]
+    [Theory]
+    public void Number_fails(string input)
+    {
+        AssertFail(input, "Number");
+    }
+
+    [InlineData("\"\"")]
+    [InlineData("\"Some text\"")]
+    [InlineData("\"Some \"\" text\"")]
+    [InlineData("\"\uD83E\uDD8A\"")] // Fox face through surrogates
+    [Theory]
+    public void Text_ok(string input)
+    {
+        AssertToken(TokenType.Text, input);
+    }
+
+    [InlineData("\"")]
+    [InlineData("\"text")]
+    [InlineData("\"text\"\"")]
+    [InlineData("\"Some \"\" text")]
+    [Theory]
+    public void Text_must_be_terminated(string input)
+    {
+        AssertFail(input, "unterminated literal");
+    }
+
+    [InlineData("\"\u0015\"")]
+    [Theory]
+    public void Text_must_be_contain_xml_10_characters(string input)
+    {
+        AssertFail(input, "Invalid text character");
+    }
+
+    [InlineData("#DIV/0!")]
+    [InlineData("#GETTING_DATA")]
+    [InlineData("#N/A")]
+    [InlineData("#NAME?")]
+    [InlineData("#NULL!")]
+    [InlineData("#NUM!")]
+    [InlineData("#REF!")]
+    [InlineData("#VALUE!")]
+    [InlineData("#ref!")]
+    [Theory]
+    public void Error_ok(string input)
+    {
+        AssertToken(TokenType.Error, input);
+    }
+
+    [Fact]
+    public void Lexer_throws_on_unpaired_surrogates()
+    {
+        // Either Visual Studio or NUnit is converting invalid surrogates to -1/65536. O
+        var invalidCodeUnits = new[]
+        {
+            "\uD83E", // Unpaired high surrogate for Fox Face
+            "\uD83E*", // Unpaired high surrogate for Fox Face
+            "\uDD8A", // Unpaired low surrogate for Fox Face
+            "\uDD8A*\"", // Unpaired low surrogate for Fox Face
+            "\uDD8A\uD83E", // Low surrogate first
+        };
+        foreach (var invalidText in invalidCodeUnits)
+        {
+            AssertFail(invalidText, "surrogate");
+        }
+    }
+
+    [InlineData("''")]
+    [InlineData("'[1]Something'")]
+    [InlineData("'Jane''s'")]
+    [InlineData("'New York'")]
+    [InlineData("'January 1st:December 31st'")]
+    [InlineData("'[7]Year 20:Year 25'")]
+    [InlineData("'[Book.xlsx]Year 20:Year 25'")]
+    [InlineData("'[End*Near.xlsx]Final'")]
+    [InlineData("''''''")]
+    [Theory]
+    public void QIdent_ok(string input)
+    {
+        AssertToken(TokenType.QIdent, input);
+    }
+
+    [InlineData("'")]
+    [InlineData("'Jane''s")]
+    [InlineData("'''''")]
+    [Theory]
+    public void QIdent_must_be_terminated(string input)
+    {
+        AssertFail(input, "unterminated literal");
+    }
+
+    [InlineData("ABC")]
+    [InlineData("A1")]
+    [InlineData("$A$1")]
+    [InlineData("AEF$A$1")]
+    [InlineData("name")]
+    [InlineData("TRUE")]
+    [InlineData("FALSE")]
+    [InlineData("true")]
+    [InlineData("false")]
+    [InlineData("?name")]
+    [InlineData("\\name")]
+    [InlineData("_name")]
+    [InlineData("name?")]
+    [InlineData("name\\")]
+    [InlineData("name_")]
+    [InlineData("some.name")]
+    [InlineData("_xlfn.ACOT")]
+    [InlineData("\u05D0\u05D1\u05E0")] // stone in hebrew - Letters from other languages
+    [InlineData("\u05E9\u05B0\u05DC\u05D5\u05DD")] // shalom - A mark from other languages
+    [Theory]
+    public void Ident_ok(string input)
+    {
+        AssertToken(TokenType.Ident, input);
+    }
+
+    [Fact]
+    public void Ident_stops_at_operators()
+    {
+        var operators = new Dictionary<TokenType, string>
+        {
+            { TokenType.Bang, "!" },
+            { TokenType.Comma, "," },
+            { TokenType.Semicolon, ";" },
+            { TokenType.Pow, "^" },
+            { TokenType.Mul, "*" },
+            { TokenType.Div, "/" },
+            { TokenType.Plus, "+" },
+            { TokenType.Minus, "-" },
+            { TokenType.Concat, "&" },
+            { TokenType.Equal, "=" },
+            { TokenType.NotEqual, "<>" },
+            { TokenType.Less, "<" },
+            { TokenType.LessEqual, "<=" },
+            { TokenType.Greater, ">" },
+            { TokenType.GreaterEqual, ">=" },
+            { TokenType.Percent, "%" },
+            { TokenType.Range, ":" },
+            { TokenType.Spill, "#" },
+            { TokenType.Intersection, "@" },
+            { TokenType.LeftParen, "(" },
+            { TokenType.RightParen, ")" },
+            { TokenType.LeftCurly, "{" },
+            { TokenType.RightCurly, "}" },
+            { TokenType.Whitespace, " " },
+        };
+
+        foreach (var (opType, opText) in operators)
+        {
+            var input = "name" + opText;
+            var lexer = new Lexer(input);
+
+            var identToken = lexer.Consume();
+            Assert.Equal(TokenType.Ident, identToken.Type);
+            Assert.Equal("name", identToken.GetText(input).ToString());
+
+            var opToken = lexer.Consume();
+            Assert.Equal(opType, opToken.Type);
+            Assert.Equal(opText, opToken.GetText(input).ToString());
+        }
+    }
+
+    [InlineData("[1]")]
+    [InlineData("[]")]
+    [InlineData("['[]")]
+    [InlineData("[Book1.xlsx]")]
+    [InlineData("[#Data]")]
+    [InlineData("[[#Data]]")]
+    [InlineData("[[#Data],[#Headers]]")]
+    [InlineData("['#]")]
+    [InlineData("[985]")]
+    [InlineData("[Jan:Dec]")]
+    [InlineData("['['['[]")]
+    [InlineData("[']']']]")]
+    [Theory]
+    public void SquareIdent_ok(string input)
+    {
+        AssertToken(TokenType.SquareIdent, input);
+    }
+
+    [InlineData("[Ja[[a]]]")]
+    [Theory]
+    public void SquareIdent_at_most_two_nested_brackets(string input)
+    {
+        // Mostly to keep within something DFA can do.
+        AssertFail(input, "at most two nested square brackets");
+    }
+
+    [InlineData("[")]
+    [InlineData("[text")]
+    [InlineData("[[")]
+    [InlineData("[a[b")]
+    [InlineData("[Start[]and end")]
+    [InlineData("[Start[']and end']")]
+    [Theory]
+    public void SquareIdent_must_be_paired(string input)
+    {
+        AssertFail(input, "Unable to find closing square bracket");
+    }
+
+    [InlineData((int)TokenType.Bang, "!")]
+    [InlineData((int)TokenType.Range, ":")]
+    [InlineData((int)TokenType.Comma, ",")]
+    [InlineData((int)TokenType.Semicolon, ";")]
+    [InlineData((int)TokenType.Pow, "^")]
+    [InlineData((int)TokenType.Mul, "*")]
+    [InlineData((int)TokenType.Div, "/")]
+    [InlineData((int)TokenType.Plus, "+")]
+    [InlineData((int)TokenType.Minus, "-")]
+    [InlineData((int)TokenType.Concat, "&")]
+    [InlineData((int)TokenType.Percent, "%")]
+    [InlineData((int)TokenType.Spill, "#")]
+    [InlineData((int)TokenType.Intersection, "@")]
+    [InlineData((int)TokenType.LeftParen, "(")]
+    [InlineData((int)TokenType.RightParen, ")")]
+    [InlineData((int)TokenType.LeftCurly, "{")]
+    [InlineData((int)TokenType.RightCurly, "}")]
+    [Theory]
+    public void Single_char_tokens_ok(int token, string input)
+    {
+        // TODO: Dump xUnit. Can't even use internal classes as test fixtures, so I have to pass enum as int.
+        AssertToken((TokenType)token, input);
+    }
+
+    [InlineData((int)TokenType.Equal, "=")]
+    [InlineData((int)TokenType.NotEqual, "<>")]
+    [InlineData((int)TokenType.Less, "<")]
+    [InlineData((int)TokenType.LessEqual, "<=")]
+    [InlineData((int)TokenType.Greater, ">")]
+    [InlineData((int)TokenType.GreaterEqual, ">=")]
+    [Theory]
+    public void Comparison_tokens_ok(int token, string input)
+    {
+        AssertToken((TokenType)token, input);
+    }
+
+    [InlineData("\t")]
+    [InlineData("\n")]
+    [InlineData("\r")]
+    [InlineData(" ")]
+    [InlineData("\t \r\n")]
+    [Theory]
+    public void Whitespace_ok(string input)
+    {
+        AssertToken(TokenType.Whitespace, input);
+    }
+
+    private static void AssertToken(TokenType type, string input)
+    {
+        var lexer = new Lexer(input);
+        var token = lexer.Consume();
+        Assert.Equal(token.Type, type);
+        Assert.Equal(token.Text, input);
+    }
+
+    private static void AssertFail(string input, string exceptionSubstring)
+    {
+        var lexer = new Lexer(input);
+        var exception = Assert.Throws<ParsingException>(() => lexer.Consume());
+        Assert.NotNull(exception);
+        Assert.True(exception.Message.Contains(exceptionSubstring), $"Expected to find '{exceptionSubstring}', but not found in '{exception.Message}'.");
+    }
+}

--- a/src/ClosedXML.Parser.Tests/Lexers/LexerTests.cs
+++ b/src/ClosedXML.Parser.Tests/Lexers/LexerTests.cs
@@ -316,8 +316,8 @@ public class LexerTests
     {
         var lexer = new Lexer(input);
         var token = lexer.Consume();
-        Assert.Equal(token.Type, type);
-        Assert.Equal(token.Text, input);
+        Assert.Equal(type, token.Type);
+        Assert.Equal(input, token.GetText(input).ToString());
     }
 
     private static void AssertFail(string input, string exceptionSubstring)

--- a/src/ClosedXML.Parser/ParsingException.cs
+++ b/src/ClosedXML.Parser/ParsingException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using ClosedXML.Parser.Pratt;
 
 namespace ClosedXML.Parser;
 
@@ -9,5 +10,37 @@ public class ParsingException : Exception
 {
     internal ParsingException(string message) : base(message)
     {
+    }
+
+    /// <summary>
+    /// There are problems with underlying stream.
+    /// </summary>
+    internal static ParsingException UnpairedSurrogate(int codepoint, int position)
+    {
+        throw new ParsingException($"Found an unpaired surrogate 0x{codepoint:X4} at {position}.");
+    }
+
+    /// <summary>
+    /// Token has a start and end indicator, but no end indicator was found.
+    /// </summary>
+    internal static Exception UnterminatedLiteral(int start, char delimiter)
+    {
+        throw new ParsingException($"An unterminated literal (delimiter {delimiter}) found at position {start}.");
+    }
+
+    /// <summary>
+    /// A token was started to be parsed, but is not complete or there is a problem with it.
+    /// </summary>
+    internal static Exception TokenPartialMatch(int start, TokenType type)
+    {
+        throw new ParsingException($"Token {type} was parsed from position {start}, but was only partially matched.");
+    }
+
+    /// <summary>
+    /// Lexer has no idea which token it should start to parse.
+    /// </summary>
+    internal static Exception UnableToSelectToken(int start)
+    {
+        throw new ParsingException($"Unable to determine a token at position {start}.");
     }
 }

--- a/src/ClosedXML.Parser/Pratt/Lexer.cs
+++ b/src/ClosedXML.Parser/Pratt/Lexer.cs
@@ -64,7 +64,7 @@ internal class Lexer
             Advance();
 
         if (IsEof)
-            return new Token(TokenType.Eof, string.Empty);
+            return new Token(TokenType.Eof, 0, 0);
 
         _start = _i;
 
@@ -412,7 +412,7 @@ internal class Lexer
 
     private Token T(TokenType type)
     {
-        return new Token(type, _input.Substring(_start, _i - _start));
+        return new Token(type, _start, _i);
     }
 
     private int Advance()

--- a/src/ClosedXML.Parser/Pratt/Lexer.cs
+++ b/src/ClosedXML.Parser/Pratt/Lexer.cs
@@ -1,0 +1,446 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Xml;
+
+namespace ClosedXML.Parser.Pratt;
+
+/// <summary>
+/// A lexer for pratt parser.
+/// </summary>
+internal class Lexer
+{
+    private const string OPERATOR_CHARS = "!,;^*/+-&=<>%:#@(){} ";
+    private const int EOF = -1;
+
+    private static readonly bool[] IsOp;
+
+    private readonly Queue<Token> _queue = new(4);
+    private readonly string _input;
+
+    private int _start; // The start index of currently parsed token in Next()
+    private int _i; // Index of current code point _c in _input
+    private int _c; // A current code point (including astral planes) or -1 if at the EOF
+
+
+    static Lexer()
+    {
+        IsOp = new bool[128];
+        foreach (var op in OPERATOR_CHARS)
+            IsOp[op] = true;
+    }
+
+    /// <summary>
+    /// Create a new instance of a lexer.
+    /// </summary>
+    /// <param name="input">Formula to tokenize.</param>
+    public Lexer(string input)
+    {
+        _input = input ?? throw new ArgumentNullException();
+        _i = -1;
+    }
+
+    private bool IsEof => _c == EOF;
+
+    public Token Consume()
+    {
+        if (_queue.Count == 0)
+            return Next();
+
+        return _queue.Dequeue();
+    }
+
+    public Token Peek()
+    {
+        if (_queue.Count == 0)
+            _queue.Enqueue(Next());
+
+        return _queue.Peek();
+    }
+
+    private Token Next()
+    {
+        if (_i < 0)
+            Advance();
+
+        if (IsEof)
+            return new Token(TokenType.Eof, string.Empty);
+
+        _start = _i;
+
+        // Number
+        if (IsDigit(_c))
+        {
+            // Whole number part
+            DigitSequence();
+
+            // Fractional part
+            if (_c == '.')
+            {
+                Advance();
+                DigitSequence();
+            }
+
+            ExponentPart();
+
+            return T(TokenType.Number);
+        }
+        if (_c is '.')
+        {
+            Advance();
+
+            // Fractional part
+            DigitSequence();
+            ExponentPart();
+
+            return T(TokenType.Number);
+        }
+
+        // Text
+        if (_c == '"')
+        {
+            Advance();
+
+            while (!IsEof)
+            {
+                if (_c == '"')
+                {
+                    Advance();
+                    if (_c != '"')
+                        return T(TokenType.Text);
+                }
+
+                if (!IsXml10Char(_c))
+                    throw new ParsingException($"Invalid text character (codepoint {_c:x8}).");
+
+                Advance();
+            }
+
+            throw ParsingException.UnterminatedLiteral(_start, '"');
+        }
+
+        // QIdent
+        if (_c == '\'')
+        {
+            while (!IsEof)
+            {
+                Advance();
+
+                if (_c == '\'')
+                {
+                    Advance();
+                    if (_c != '\'')
+                        return T(TokenType.QIdent);
+                }
+            }
+
+            throw ParsingException.UnterminatedLiteral(_start, '\'');
+        }
+
+        if (IsIdentStart(_c))
+        {
+            Advance();
+            while (!IsEof && IsIdentNext(_c))
+                Advance();
+
+            return T(TokenType.Ident);
+        }
+
+        if (_c == '+')
+            return FoundToken(TokenType.Plus);
+
+        if (_c == '-')
+            return FoundToken(TokenType.Minus);
+
+        if (_c == '*')
+            return FoundToken(TokenType.Mul);
+
+        if (_c == '/')
+            return FoundToken(TokenType.Div);
+
+        if (_c == '^')
+            return FoundToken(TokenType.Pow);
+
+        if (_c == '%')
+            return FoundToken(TokenType.Percent);
+
+        if (_c == '&')
+            return FoundToken(TokenType.Concat);
+
+        if (_c == '!')
+            return FoundToken(TokenType.Bang);
+
+        if (_c == '(')
+            return FoundToken(TokenType.LeftParen);
+
+        if (_c == ')')
+            return FoundToken(TokenType.RightParen);
+
+        if (_c == '{')
+            return FoundToken(TokenType.LeftCurly);
+
+        if (_c == '}')
+            return FoundToken(TokenType.RightCurly);
+
+        if (_c == ',')
+            return FoundToken(TokenType.Comma);
+
+        if (_c == ';')
+            return FoundToken(TokenType.Semicolon);
+
+        if (_c == ':')
+            return FoundToken(TokenType.Range);
+
+        if (_c == '@')
+            return FoundToken(TokenType.Intersection);
+
+        // Comparison
+        if (_c == '=')
+            return FoundToken(TokenType.Equal);
+
+        if (_c == '<')
+        {
+            var next = Advance();
+            if (next == '>')
+                return FoundToken(TokenType.NotEqual);
+
+            if (next == '=')
+                return FoundToken(TokenType.LessEqual);
+
+            return T(TokenType.Less);
+        }
+
+        if (_c == '>')
+        {
+            if (Advance() == '=')
+            {
+                return FoundToken(TokenType.GreaterEqual);
+            }
+
+            return T(TokenType.Greater);
+        }
+
+        if (IsWhitespace(_c))
+        {
+            do
+            {
+                Advance();
+            } while (IsWhitespace(_c));
+
+            return T(TokenType.Whitespace);
+        }
+
+        // Spill operator and errors
+        if (_c == '#')
+        {
+            var char1 = Advance();
+            switch (char1)
+            {
+                case 'D' or 'd':
+                    return Error("#DIV/0!", 2);
+                case 'R' or 'r':
+                    return Error("#REF!", 2);
+                case 'V' or 'v':
+                    return Error("#VALUE!", 2);
+                case 'G' or 'g':
+                    return Error("#GETTING_DATA", 2);
+                case 'N' or 'n':
+                    {
+                        var char2 = Advance();
+                        if (char2 == '/')
+                            return Error("#N/A", 3);
+
+                        if (char2 == 'A')
+                            return Error("#NAME?", 3);
+
+                        var char3 = Advance();
+                        if (char2 == 'U' && char3 == 'L')
+                            return Error("#NULL!", 4);
+
+                        if (char2 == 'U' && char3 == 'M')
+                            return Error("#NUM!", 4);
+
+                        throw ParsingException.TokenPartialMatch(_start, TokenType.Error);
+                    }
+            }
+
+            return T(TokenType.Spill);
+        }
+
+        if (_c == '[')
+        {
+            var level = 0;
+            do
+            {
+                switch (_c)
+                {
+                    case '[':
+                        ++level;
+                        break;
+                    case ']':
+                        --level;
+                        break;
+                    case '\'':
+                        Advance(); // Escaped chars don't change level - skip
+                        break;
+                }
+
+                if (IsEof)
+                    throw new ParsingException($"Unable to find closing square bracket for token from position {_start}.");
+
+                if (level > 2)
+                    throw new ParsingException($"There can be at most two nested square brackets in a token from position {_start}.");
+
+                Advance();
+            } while (level > 0);
+
+            return T(TokenType.SquareIdent);
+        }
+
+        throw ParsingException.UnableToSelectToken(_start);
+
+        static bool IsWhitespace(int c)
+        {
+            return c is ' ' or '\r' or '\n' or '\t';
+        }
+
+        static bool IsDigit(int c)
+        {
+            return c is >= '0' and <= '9';
+        }
+
+        // Check [0-9]+
+        void DigitSequence()
+        {
+            do
+            {
+                if (!IsDigit(_c))
+                    throw ParsingException.TokenPartialMatch(_start, TokenType.Number);
+                Advance();
+            }
+            while (!IsEof && IsDigit(_c));
+        }
+
+        void ExponentPart()
+        {
+            if (_c is 'e' or 'E')
+            {
+                if (Advance() is '+' or '-')
+                    Advance();
+
+                DigitSequence();
+            }
+        }
+
+        static bool IsIdentStart(int c)
+        {
+            // Ident must satisfy logical-literal, sheet-name, name and A1-cell/column/row
+            return
+                IsAsciiLetter(c) || // name + A1
+                c == '$' || // A1
+                (c is '_' or '\\' or '?') || // name
+                (c > 0x7F && IsLetterOrLetterMark(c)); // name
+        }
+
+        static bool IsIdentNext(int c)
+        {
+            // Stop at operators
+            if (c < IsOp.Length && IsOp[c])
+                return false;
+
+            return IsIdentStart(c) ||
+                c is >= '0' and <= '9' ||  // name, A1
+                c == '.'; // name + future-functions
+        }
+
+        Token Error(string error, int start)
+        {
+            foreach (var errorChar in error.AsSpan().Slice(start))
+            {
+                Advance();
+                if (ToUpperAlpha(_c) != errorChar)
+                    throw ParsingException.TokenPartialMatch(_start, TokenType.Error);
+            }
+
+            Advance();
+            return T(TokenType.Error);
+        }
+
+        // Token that ends at the Current has been found. Advance to next and return token.
+        Token FoundToken(TokenType type)
+        {
+            Advance();
+            return T(type);
+        }
+
+        // Convert a-z to A-Z, keep other codepoints same.
+        static int ToUpperAlpha(int codepoint)
+        {
+            return codepoint is >= 'a' and <= 'z'
+                ? 'A' + codepoint - 'a'
+                : codepoint;
+        }
+
+        static bool IsAsciiLetter(int codepoint)
+        {
+            // Convert to lowercase, normalize 'a' to 0, and check if within 0 (~A)..25(~Z).
+            // Really cool use of cast int to uint (-1 to 0xFFFFFFFF), thus saving one comparison
+            // and avoiding potential pipeline stall.
+            return (uint)((codepoint | 32) - 97) <= 25U;
+        }
+
+        static bool IsLetterOrLetterMark(int codepoint)
+        {
+            // TODO: Only netstandard 2.1 has a parameter of type int, 2.0 has only char.
+            if (codepoint > 0xFFFF)
+                return false; // No letters from astral planes for us :(
+
+            // Letters are categories from 0 to OtherLetter category. Then there are NonSpacingMark (accents and such).
+            return CharUnicodeInfo.GetUnicodeCategory((char)codepoint) <= UnicodeCategory.NonSpacingMark;
+        }
+
+        // Is codepoint a character per XML 1.0 spec (2.2)?
+        static bool IsXml10Char(int codepoint)
+        {
+            // .NET is using a lookup table with properties
+            if (codepoint <= 0xFFFF)
+                return XmlConvert.IsXmlChar((char)codepoint);
+
+            return codepoint <= 0x10FFFF;
+        }
+    }
+
+    private Token T(TokenType type)
+    {
+        return new Token(type, _input.Substring(_start, _i - _start));
+    }
+
+    private int Advance()
+    {
+        if (++_i >= _input.Length)
+        {
+            _c = -1;
+            return (char)_c;
+        }
+
+        var c = _input[_i];
+
+        if (char.IsLowSurrogate(c))
+            throw ParsingException.UnpairedSurrogate(c, _i);
+
+        if (char.IsHighSurrogate(c))
+        {
+            if (_i + 1 >= _input.Length)
+                throw ParsingException.UnpairedSurrogate(c, _i);
+
+            var low = _input[++_i];
+            if (!char.IsLowSurrogate(low))
+                throw ParsingException.UnpairedSurrogate(c, _i - 1);
+
+            _c = char.ConvertToUtf32(c, low);
+            return _c;
+        }
+
+        return _c = c;
+    }
+}

--- a/src/ClosedXML.Parser/Pratt/Token.cs
+++ b/src/ClosedXML.Parser/Pratt/Token.cs
@@ -1,14 +1,21 @@
-﻿namespace ClosedXML.Parser.Pratt;
+﻿using System;
+
+namespace ClosedXML.Parser.Pratt;
 
 internal readonly struct Token
 {
-    public Token(TokenType type, string text)
+    private readonly SymbolRange _text;
+
+    public Token(TokenType type, int start, int end)
     {
         Type = type;
-        Text = text;
+        _text = new SymbolRange(start, end);
     }
 
     public TokenType Type { get; }
 
-    public string Text { get; }
+    public ReadOnlySpan<char> GetText(string input)
+    {
+        return input.AsSpan(_text.Start, _text.Length);
+    }
 }

--- a/src/ClosedXML.Parser/Pratt/Token.cs
+++ b/src/ClosedXML.Parser/Pratt/Token.cs
@@ -1,0 +1,14 @@
+﻿namespace ClosedXML.Parser.Pratt;
+
+internal readonly struct Token
+{
+    public Token(TokenType type, string text)
+    {
+        Type = type;
+        Text = text;
+    }
+
+    public TokenType Type { get; }
+
+    public string Text { get; }
+}

--- a/src/ClosedXML.Parser/Pratt/TokenType.cs
+++ b/src/ClosedXML.Parser/Pratt/TokenType.cs
@@ -104,34 +104,124 @@ internal enum TokenType
     Bang,
 
     // Operators
+    /// <summary>
+    /// <c>,</c> - argument separator in function call, range union operator, or separator of
+    /// values in a row for an array literal.
+    /// </summary>
     Comma,
+
+    /// <summary>
+    /// <c>;</c> - separator of rows in array literal.
+    /// </summary>
     Semicolon,
+
+    /// <summary>
+    /// <c>^</c> - power operator.
+    /// </summary>
     Pow,
+
+    /// <summary>
+    /// <c>*</c> - multiplication operator.
+    /// </summary>
     Mul,
+
+    /// <summary>
+    /// <c>/</c> - division operator.
+    /// </summary>
     Div,
+
+    /// <summary>
+    /// <c>-</c> - prefix or binary plus operator.
+    /// </summary>
     Plus,
+
+    /// <summary>
+    /// <c>-</c> - prefix or binary minus operator.
+    /// </summary>
     Minus,
+
+    /// <summary>
+    /// <c>&amp;</c> - text concatenation operator.
+    /// </summary>
     Concat,
+
+    /// <summary>
+    /// <c>=</c> equal comparison operator.
+    /// </summary>
     Equal,
+
+    /// <summary>
+    /// <c>&lt;&gt;</c> not equals comparison operator.
+    /// </summary>
     NotEqual,
+
+    /// <summary>
+    /// <c>&lt;</c> less than comparison operator.
+    /// </summary>
     Less,
+
+    /// <summary>
+    /// <c>&lt;=</c> less than or equal comparison operator.
+    /// </summary>
     LessEqual,
+
+    /// <summary>
+    /// <c>&gt;</c> greater than comparison operator.
+    /// </summary>
     Greater,
+
+    /// <summary>
+    /// <c>&gt;=</c> greater than or equal comparison operator.
+    /// </summary>
     GreaterEqual,
+
+    /// <summary>
+    /// <c>%</c> postfix operator.
+    /// </summary>
     Percent,
 
-    // Reference operators
+    /// <summary>
+    /// <c>:</c> - range of two references.
+    /// </summary>
     Range,
+
+    /// <summary>
+    /// <c>#</c> - postfix reference operator.
+    /// </summary>
     Spill,
+
+    /// <summary>
+    /// <c>@</c> - implicit intersection of reference.
+    /// </summary>
     Intersection,
 
-    // Misc
+    /// <summary>
+    /// <c>(</c> - a nested group operator or opening parenthesis of a function call.
+    /// </summary>
     LeftParen,
+
+    /// <summary>
+    /// <c>)</c> - a nested group operator or closing parenthesis of a function call.
+    /// </summary>
     RightParen,
+
+    /// <summary>
+    /// <c>{</c> - opening token of array literal.
+    /// </summary>
     LeftCurly,
+
+    /// <summary>
+    /// <c>}</c> - closing token of array literal.
+    /// </summary>
     RightCurly,
 
-    // Might contain even space, which is intersection operator, but depends on context
+    /// <summary>
+    /// <c> </c> - binary intersection operator or whitespace that will be ignored by parser.
+    /// </summary>
     Whitespace,
+
+    /// <summary>
+    /// End of file.
+    /// </summary>
     Eof,
 }

--- a/src/ClosedXML.Parser/Pratt/TokenType.cs
+++ b/src/ClosedXML.Parser/Pratt/TokenType.cs
@@ -1,0 +1,137 @@
+﻿namespace ClosedXML.Parser.Pratt;
+
+/// <summary>
+/// A token types for a lexer.
+/// </summary>
+internal enum TokenType
+{
+    /// <summary>
+    /// An identifier in a formula. In most generic form, it's a name.
+    /// Essentially a text that doesn't start with a number without a whitespace.
+    /// Includes following rules from ABNF:
+    /// <list type="bullet">
+    ///   <item>A1-column, A1-row, A1-cell</item>
+    ///   <item>name</item>
+    ///   <item>logical-constant</item>
+    ///   <item>sheet-name</item>
+    /// </list>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Excel doesn't have clear distinction between identifiers and keywords or other things.
+    /// Example: <c>LOG10</c> could be an A1 reference name (column <c>LOG</c>, row <c>10</c>),
+    /// a function (<c>LOG10(14)</c>) or sheet name (<c>LOG10!A1</c>). To determine it, parser
+    /// needs a context. And context isn't available in the lexer.
+    /// </para>
+    /// <para>
+    /// Unlike A1, R1C1 has to be recognized in a parser. The minus sign along with square
+    /// brackets in a <c>R[-1]C[-1]</c> is a deal-breaker.
+    /// </para>
+    /// </remarks>
+    Ident, // TODO: sheet-name rule description is obviously not true, needs to be checked manually
+
+    /// <summary>
+    /// A floating point number. The textual representation isn't limited number to maximum
+    /// precision of IEEE 754 standard.
+    /// </summary>
+    Number,
+
+    /// <summary>
+    /// A text inside double quotes. Double quotes are escaped by doubling.
+    /// </summary>
+    Text,
+
+    /// <summary>
+    /// Error literal, e.g. <c>#N/A</c>.
+    /// </summary>
+    Error,
+
+    /// <summary>
+    /// A token representing text between two single quotes. Single quotes are escaped by doubling.
+    /// <list type="bullet">
+    ///  <item><c>'Jane''s'</c> - sheet names with escaped character</item>
+    ///  <item><c>'New York'</c> - sheet names with spaces</item>
+    ///  <item><c>'January 1st:December 31st'</c> - 3D references of sheets with spaces</item>
+    ///  <item><c>'[7]Year 20:Year 25'</c> - 3D references to external workbook.</item>
+    ///  <item><c>'[Book.xlsx]Year 20:Year 25'</c> - 3D references to external workbook.</item>
+    /// </list>
+    /// </summary>
+    /// <remarks>
+    /// The ABNF says 
+    /// <code>
+    ///   sheet-name-special = sheet-name-base-character [*sheet-name-character-special sheet-name-base-character]
+    ///   sheet-name-character-special = 2apostrophe / sheet-name-base-character
+    ///   sheet-name-base-character = character; MUST NOT be ', *, [, ], \, :, /, ?, or Unicode character 'END OF TEXT'
+    ///   character = as defined by the production Char in the [W3C-XML] section 2.2
+    /// </code>
+    /// but we accept everything in lexer. The <c>[</c> and <c>]</c> must be part of it due
+    /// to workbook index or <c>*</c> could be a valid name of a workbook. Since is has to be
+    /// filtered in the parser anyway, don't burden the lexer.
+    /// </remarks>
+    QIdent,
+
+    /// <summary>
+    /// A span of content inside a square brackets. The token inside brackets includes escaped
+    /// brackets and structure reference keywords.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// There is a problem with it being either book
+    /// reference or structure reference. In addition, we might want to parse names of book files
+    /// in the future. Lexer should be doable through DFA and this is really hard, so just detect
+    /// token and leave decision to the parser. Nested square brackets are not allowed (must be
+    /// escaped), so there are at most two level deep nested brackets (<c>[[#Header],[#Data]]</c>),
+    /// which is doable by DFA (unlimited nesting isn't).
+    /// </para>
+    /// <para>
+    /// Examples:
+    /// <list type="bullet">
+    ///  <item><c>[1]</c> - either structure reference to a column '1' or book index.</item>
+    ///  <item><c>[]</c> - structure reference to a whole table (from first to last).</item>
+    ///  <item><c>['[]</c> - structure reference to a column '['.</item>
+    ///  <item><c>[Book1.xlsx]</c> - book reference, not part of official grammar.</item>
+    ///  <item><c>[#Data]</c> - structure reference to data portion of a table</item>
+    ///  <item><c>[[#Data]]</c> - Nested reference</item>
+    ///  <item><c>['#]</c> - structure reference to a column '#'</item>
+    /// </list>
+    /// </para>
+    /// </remarks>
+    SquareIdent,
+
+    /// <summary>
+    /// Bang <c>!</c>. It is used in sheet reference, bang names and bang references.
+    /// </summary>
+    Bang,
+
+    // Operators
+    Comma,
+    Semicolon,
+    Pow,
+    Mul,
+    Div,
+    Plus,
+    Minus,
+    Concat,
+    Equal,
+    NotEqual,
+    Less,
+    LessEqual,
+    Greater,
+    GreaterEqual,
+    Percent,
+
+    // Reference operators
+    Range,
+    Spill,
+    Intersection,
+
+    // Misc
+    LeftParen,
+    RightParen,
+    LeftCurly,
+    RightCurly,
+
+    // Might contain even space, which is intersection operator, but depends on context
+    Whitespace,
+    Eof,
+}


### PR DESCRIPTION
This is a lexer for version 3.0 that should use Pratt parsing.

New token structure and pratt parser should solve some long-term issues that were rather annoying in original lexer + recursive parser. 2.0 had too much logic in lexer and tokens were modeled after ABNF grammar. Not a great choice. I am not too happy with recursive parser either. Some issues that had problems:
* `LOG10` can be reference to column LOG and row 10, function LOG10(14), or a sheet name
*  bang names and references
* `[1]` can be part of external book references (e.g, `[4]Sheet!A1`), structure reference to a column named `1` in a table or even be part of R[1]C[1].

The lexer is handmade, though representable in DFA if necessary. Not a very big fan of DFA generation, tooling is just not there, has to be patched manually and so on.

After experience with 2.0, it seems that too much was done in lexer and the lexer produce far less tokens and should be far more "relaxed". That means parser will have to deal with more relaxed tokens that might not be valid in used context.

Performance is acceptable (150ms for tokenization of 22MB of enron formulas), but that is because it's rather simple. A lot of logic will be in the pratt parser.

